### PR TITLE
Migrate to HttpOnly Cookie Auth + CSRF Protection

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -40,7 +40,7 @@ services:
     env_file:
       - .env
     environment:
-      APP_ENV: local # production
+      APP_ENV: production # production
       COOKIE_DOMAIN: .swua.kr
       GIN_MODE: release
       AWS_EC2_METADATA_DISABLED: "true"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -40,6 +40,7 @@ services:
     env_file:
       - .env
     environment:
+      APP_ENV: local # production
       GIN_MODE: release
       AWS_EC2_METADATA_DISABLED: "true"
       S3_ACCESS_KEY_ID: ${S3_ACCESS_KEY_ID:-}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -41,6 +41,7 @@ services:
       - .env
     environment:
       APP_ENV: local # production
+      COOKIE_DOMAIN: .swua.kr
       GIN_MODE: release
       AWS_EC2_METADATA_DISABLED: "true"
       S3_ACCESS_KEY_ID: ${S3_ACCESS_KEY_ID:-}

--- a/docs/docs/admin.md
+++ b/docs/docs/admin.md
@@ -2,7 +2,10 @@
 title: Admin
 nav_order: 6
 ---
----
+
+Notes:
+
+- For authenticated `POST`, `PUT`, `PATCH`, and `DELETE` requests, send both `csrf_token` cookie and matching `X-CSRF-Token` header.
 
 ## Block User
 
@@ -38,7 +41,7 @@ Response 200
 Errors:
 
 - 400 `invalid input`
-- 401 `invalid token` or `missing access_token cookie` or `invalid token`
+- 401 `invalid token` or `missing access_token cookie`
 - 403 `forbidden`
 - 404 `not found`
 
@@ -70,7 +73,7 @@ Response 200
 Errors:
 
 - 400 `invalid input`
-- 401 `invalid token` or `missing access_token cookie` or `invalid token`
+- 401 `invalid token` or `missing access_token cookie`
 - 403 `forbidden`
 - 404 `not found`
 
@@ -131,7 +134,7 @@ Response 201
 Errors:
 
 - 400 `invalid input`
-- 401 `invalid token` or `missing access_token cookie` or `invalid token`
+- 401 `invalid token` or `missing access_token cookie`
 - 403 `forbidden`
 
 ---
@@ -195,7 +198,7 @@ Response 200
 Errors:
 
 - 400 `invalid input`
-- 401 `invalid token` or `missing access_token cookie` or `invalid token`
+- 401 `invalid token` or `missing access_token cookie`
 - 403 `forbidden`
 - 404 `challenge not found`
 
@@ -239,7 +242,7 @@ Response 200
 
 Errors:
 
-- 401 `invalid token` or `missing access_token cookie` or `invalid token`
+- 401 `invalid token` or `missing access_token cookie`
 - 403 `forbidden`
 - 404 `challenge not found`
 
@@ -265,7 +268,7 @@ Response 200
 
 Errors:
 
-- 401 `invalid token` or `missing access_token cookie` or `invalid token`
+- 401 `invalid token` or `missing access_token cookie`
 - 403 `forbidden`
 - 404 `challenge not found`
 
@@ -347,7 +350,7 @@ Response 200
 
 Errors (all admin stack endpoints):
 
-- 401 `invalid token` or `missing access_token cookie` or `invalid token`
+- 401 `invalid token` or `missing access_token cookie`
 - 403 `forbidden`
 - 404 `stack not found`
 - 503 `stack feature disabled` or `stack provisioner unavailable`
@@ -405,7 +408,7 @@ Response 200
 Errors:
 
 - 400 `invalid input`
-- 401 `invalid token` or `missing access_token cookie` or `invalid token`
+- 401 `invalid token` or `missing access_token cookie`
 - 403 `forbidden`
 - 404 `challenge not found`
 - 503 `storage unavailable`
@@ -443,7 +446,7 @@ Response 200
 
 Errors:
 
-- 401 `invalid token` or `missing access_token cookie` or `invalid token`
+- 401 `invalid token` or `missing access_token cookie`
 - 403 `forbidden`
 - 404 `challenge not found` or `challenge file not found`
 - 503 `storage unavailable`

--- a/docs/docs/admin.md
+++ b/docs/docs/admin.md
@@ -11,7 +11,7 @@ nav_order: 6
 Headers
 
 ```
-Authorization: Bearer <access_token>
+Cookie: access_token=<jwt>
 ```
 
 Request
@@ -38,7 +38,7 @@ Response 200
 Errors:
 
 - 400 `invalid input`
-- 401 `invalid token` or `missing authorization` or `invalid authorization`
+- 401 `invalid token` or `missing access_token cookie` or `invalid token`
 - 403 `forbidden`
 - 404 `not found`
 
@@ -51,7 +51,7 @@ Errors:
 Headers
 
 ```
-Authorization: Bearer <access_token>
+Cookie: access_token=<jwt>
 ```
 
 Response 200
@@ -70,7 +70,7 @@ Response 200
 Errors:
 
 - 400 `invalid input`
-- 401 `invalid token` or `missing authorization` or `invalid authorization`
+- 401 `invalid token` or `missing access_token cookie` or `invalid token`
 - 403 `forbidden`
 - 404 `not found`
 
@@ -83,7 +83,7 @@ Errors:
 Headers
 
 ```
-Authorization: Bearer <access_token>
+Cookie: access_token=<jwt>
 ```
 
 Request
@@ -131,7 +131,7 @@ Response 201
 Errors:
 
 - 400 `invalid input`
-- 401 `invalid token` or `missing authorization` or `invalid authorization`
+- 401 `invalid token` or `missing access_token cookie` or `invalid token`
 - 403 `forbidden`
 
 ---
@@ -143,7 +143,7 @@ Errors:
 Headers
 
 ```
-Authorization: Bearer <access_token>
+Cookie: access_token=<jwt>
 ```
 
 Request
@@ -195,7 +195,7 @@ Response 200
 Errors:
 
 - 400 `invalid input`
-- 401 `invalid token` or `missing authorization` or `invalid authorization`
+- 401 `invalid token` or `missing access_token cookie` or `invalid token`
 - 403 `forbidden`
 - 404 `challenge not found`
 
@@ -208,7 +208,7 @@ Errors:
 Headers
 
 ```
-Authorization: Bearer <access_token>
+Cookie: access_token=<jwt>
 ```
 
 Response 200
@@ -239,7 +239,7 @@ Response 200
 
 Errors:
 
-- 401 `invalid token` or `missing authorization` or `invalid authorization`
+- 401 `invalid token` or `missing access_token cookie` or `invalid token`
 - 403 `forbidden`
 - 404 `challenge not found`
 
@@ -252,7 +252,7 @@ Errors:
 Headers
 
 ```
-Authorization: Bearer <access_token>
+Cookie: access_token=<jwt>
 ```
 
 Response 200
@@ -265,7 +265,7 @@ Response 200
 
 Errors:
 
-- 401 `invalid token` or `missing authorization` or `invalid authorization`
+- 401 `invalid token` or `missing access_token cookie` or `invalid token`
 - 403 `forbidden`
 - 404 `challenge not found`
 
@@ -276,7 +276,7 @@ Errors:
 Headers
 
 ```
-Authorization: Bearer <access_token>
+Cookie: access_token=<jwt>
 ```
 
 ### List All Stacks
@@ -347,7 +347,7 @@ Response 200
 
 Errors (all admin stack endpoints):
 
-- 401 `invalid token` or `missing authorization` or `invalid authorization`
+- 401 `invalid token` or `missing access_token cookie` or `invalid token`
 - 403 `forbidden`
 - 404 `stack not found`
 - 503 `stack feature disabled` or `stack provisioner unavailable`
@@ -361,7 +361,7 @@ Errors (all admin stack endpoints):
 Headers
 
 ```
-Authorization: Bearer <access_token>
+Cookie: access_token=<jwt>
 ```
 
 Request
@@ -405,7 +405,7 @@ Response 200
 Errors:
 
 - 400 `invalid input`
-- 401 `invalid token` or `missing authorization` or `invalid authorization`
+- 401 `invalid token` or `missing access_token cookie` or `invalid token`
 - 403 `forbidden`
 - 404 `challenge not found`
 - 503 `storage unavailable`
@@ -419,7 +419,7 @@ Errors:
 Headers
 
 ```
-Authorization: Bearer <access_token>
+Cookie: access_token=<jwt>
 ```
 
 Response 200
@@ -443,7 +443,7 @@ Response 200
 
 Errors:
 
-- 401 `invalid token` or `missing authorization` or `invalid authorization`
+- 401 `invalid token` or `missing access_token cookie` or `invalid token`
 - 403 `forbidden`
 - 404 `challenge not found` or `challenge file not found`
 - 503 `storage unavailable`

--- a/docs/docs/affiliations.md
+++ b/docs/docs/affiliations.md
@@ -3,6 +3,10 @@ title: Affiliations
 nav_order: 9
 ---
 
+Notes:
+
+- For authenticated `POST`, `PUT`, `PATCH`, and `DELETE` requests, send both `csrf_token` cookie and matching `X-CSRF-Token` header.
+
 ## Create Affiliation (Admin)
 
 `POST /api/admin/affiliations`
@@ -33,7 +37,7 @@ Response 201
 Errors:
 
 - 400 `invalid input` (required/duplicate name)
-- 401 `invalid token` or `missing access_token cookie` or `invalid token`
+- 401 `invalid token` or `missing access_token cookie`
 - 403 `forbidden`
 
 ---

--- a/docs/docs/affiliations.md
+++ b/docs/docs/affiliations.md
@@ -10,7 +10,7 @@ nav_order: 9
 Headers
 
 ```
-Authorization: Bearer <access_token>
+Cookie: access_token=<jwt>
 ```
 
 Request
@@ -33,7 +33,7 @@ Response 201
 Errors:
 
 - 400 `invalid input` (required/duplicate name)
-- 401 `invalid token` or `missing authorization` or `invalid authorization`
+- 401 `invalid token` or `missing access_token cookie` or `invalid token`
 - 403 `forbidden`
 
 ---
@@ -156,7 +156,7 @@ Errors:
 Headers
 
 ```
-Authorization: Bearer <access_token>
+Cookie: access_token=<jwt>
 ```
 
 Request examples

--- a/docs/docs/auth.md
+++ b/docs/docs/auth.md
@@ -51,8 +51,6 @@ Response 200
 
 ```json
 {
-    "access_token": "<jwt>",
-    "refresh_token": "<jwt>",
     "user": {
         "id": 1,
         "email": "user@example.com",
@@ -77,6 +75,8 @@ Errors:
 Notes:
 
 - `stack_count` and `stack_limit` are calculated per user.
+- `access_token` and `refresh_token` are issued as `HttpOnly` cookies.
+- `csrf_token` is issued as a readable cookie for double-submit CSRF protection.
 
 ---
 
@@ -84,20 +84,13 @@ Notes:
 
 `POST /api/auth/refresh`
 
-Request
-
-```json
-{
-    "refresh_token": "<jwt>"
-}
-```
+Request: send `refresh_token` cookie (and `X-CSRF-Token` header matching `csrf_token` cookie).
 
 Response 200
 
 ```json
 {
-    "access_token": "<jwt>",
-    "refresh_token": "<jwt>"
+    "status": "ok"
 }
 ```
 
@@ -112,13 +105,7 @@ Errors:
 
 `POST /api/auth/logout`
 
-Request
-
-```json
-{
-    "refresh_token": "<jwt>"
-}
-```
+Request: send `refresh_token` cookie (and `X-CSRF-Token` header matching `csrf_token` cookie).
 
 Response 200
 

--- a/docs/docs/challenges.md
+++ b/docs/docs/challenges.md
@@ -3,6 +3,10 @@ title: Challenges
 nav_order: 4
 ---
 
+Notes:
+
+- For authenticated `POST`, `PUT`, `PATCH`, and `DELETE` requests, send both `csrf_token` cookie and matching `X-CSRF-Token` header.
+
 ## List Challenges
 
 `GET /api/challenges`
@@ -240,7 +244,7 @@ Response 200
 Errors:
 
 - 400 `invalid input`
-- 401 `invalid token` or `missing access_token cookie` or `invalid token`
+- 401 `invalid token` or `missing access_token cookie`
 - 403 `user blocked` or `challenge locked`
 - 404 `challenge not found`
 - 409 `challenge already solved`
@@ -280,7 +284,7 @@ Response 200
 Errors:
 
 - 400 `invalid input`
-- 401 `invalid token` or `missing access_token cookie` or `invalid token`
+- 401 `invalid token` or `missing access_token cookie`
 - 403 `user blocked` or `challenge not solved by user`
 - 404 `challenge not found`
 
@@ -354,7 +358,7 @@ When the caller has not voted on this challenge yet:
 Errors:
 
 - 400 `invalid input`
-- 401 `invalid token` or `missing access_token cookie` or `invalid token`
+- 401 `invalid token` or `missing access_token cookie`
 - 404 `challenge not found`
 
 ---
@@ -380,7 +384,7 @@ Response 200
 
 Errors:
 
-- 401 `invalid token` or `missing access_token cookie` or `invalid token`
+- 401 `invalid token` or `missing access_token cookie`
 - 403 `user blocked` or `challenge locked`
 - 404 `challenge not found` or `challenge file not found`
 - 503 `storage unavailable`
@@ -490,7 +494,7 @@ Response 201
 Errors:
 
 - 400 `invalid input`
-- 401 `invalid token` or `missing access_token cookie` or `invalid token`
+- 401 `invalid token` or `missing access_token cookie`
 - 403 `user blocked`
 - 404 `challenge not found`
 
@@ -541,7 +545,7 @@ Response 200
 Errors:
 
 - 400 `invalid input`
-- 401 `invalid token` or `missing access_token cookie` or `invalid token`
+- 401 `invalid token` or `missing access_token cookie`
 - 403 `user blocked` or `comment access forbidden`
 - 404 `comment not found`
 
@@ -568,6 +572,6 @@ Response 200
 Errors:
 
 - 400 `invalid input`
-- 401 `invalid token` or `missing access_token cookie` or `invalid token`
+- 401 `invalid token` or `missing access_token cookie`
 - 403 `user blocked` or `comment access forbidden`
 - 404 `comment not found`

--- a/docs/docs/challenges.md
+++ b/docs/docs/challenges.md
@@ -218,7 +218,7 @@ Errors:
 Headers
 
 ```
-Authorization: Bearer <access_token>
+Cookie: access_token=<jwt>
 ```
 
 Request
@@ -240,7 +240,7 @@ Response 200
 Errors:
 
 - 400 `invalid input`
-- 401 `invalid token` or `missing authorization` or `invalid authorization`
+- 401 `invalid token` or `missing access_token cookie` or `invalid token`
 - 403 `user blocked` or `challenge locked`
 - 404 `challenge not found`
 - 409 `challenge already solved`
@@ -255,7 +255,7 @@ Errors:
 Headers
 
 ```
-Authorization: Bearer <access_token>
+Cookie: access_token=<jwt>
 ```
 
 Request
@@ -280,7 +280,7 @@ Response 200
 Errors:
 
 - 400 `invalid input`
-- 401 `invalid token` or `missing authorization` or `invalid authorization`
+- 401 `invalid token` or `missing access_token cookie` or `invalid token`
 - 403 `user blocked` or `challenge not solved by user`
 - 404 `challenge not found`
 
@@ -332,7 +332,7 @@ Errors:
 Headers
 
 ```
-Authorization: Bearer <access_token>
+Cookie: access_token=<jwt>
 ```
 
 Response 200
@@ -354,7 +354,7 @@ When the caller has not voted on this challenge yet:
 Errors:
 
 - 400 `invalid input`
-- 401 `invalid token` or `missing authorization` or `invalid authorization`
+- 401 `invalid token` or `missing access_token cookie` or `invalid token`
 - 404 `challenge not found`
 
 ---
@@ -366,7 +366,7 @@ Errors:
 Headers
 
 ```
-Authorization: Bearer <access_token>
+Cookie: access_token=<jwt>
 ```
 
 Response 200
@@ -380,7 +380,7 @@ Response 200
 
 Errors:
 
-- 401 `invalid token` or `missing authorization` or `invalid authorization`
+- 401 `invalid token` or `missing access_token cookie` or `invalid token`
 - 403 `user blocked` or `challenge locked`
 - 404 `challenge not found` or `challenge file not found`
 - 503 `storage unavailable`
@@ -449,7 +449,7 @@ Errors:
 Headers
 
 ```
-Authorization: Bearer <access_token>
+Cookie: access_token=<jwt>
 ```
 
 Request
@@ -490,7 +490,7 @@ Response 201
 Errors:
 
 - 400 `invalid input`
-- 401 `invalid token` or `missing authorization` or `invalid authorization`
+- 401 `invalid token` or `missing access_token cookie` or `invalid token`
 - 403 `user blocked`
 - 404 `challenge not found`
 
@@ -503,7 +503,7 @@ Errors:
 Headers
 
 ```
-Authorization: Bearer <access_token>
+Cookie: access_token=<jwt>
 ```
 
 Request
@@ -541,7 +541,7 @@ Response 200
 Errors:
 
 - 400 `invalid input`
-- 401 `invalid token` or `missing authorization` or `invalid authorization`
+- 401 `invalid token` or `missing access_token cookie` or `invalid token`
 - 403 `user blocked` or `comment access forbidden`
 - 404 `comment not found`
 
@@ -554,7 +554,7 @@ Errors:
 Headers
 
 ```
-Authorization: Bearer <access_token>
+Cookie: access_token=<jwt>
 ```
 
 Response 200
@@ -568,6 +568,6 @@ Response 200
 Errors:
 
 - 400 `invalid input`
-- 401 `invalid token` or `missing authorization` or `invalid authorization`
+- 401 `invalid token` or `missing access_token cookie` or `invalid token`
 - 403 `user blocked` or `comment access forbidden`
 - 404 `comment not found`

--- a/docs/docs/stacks.md
+++ b/docs/docs/stacks.md
@@ -10,7 +10,7 @@ nav_order: 8
 Headers
 
 ```
-Authorization: Bearer <access_token>
+Cookie: access_token=<jwt>
 ```
 
 Response 200
@@ -43,7 +43,7 @@ Response 200
 
 Errors:
 
-- 401 `invalid token` or `missing authorization` or `invalid authorization`
+- 401 `invalid token` or `missing access_token cookie` or `invalid token`
 - 503 `stack feature disabled`
 
 Notes:
@@ -59,7 +59,7 @@ Notes:
 Headers
 
 ```
-Authorization: Bearer <access_token>
+Cookie: access_token=<jwt>
 ```
 
 Response 201
@@ -89,7 +89,7 @@ Response 201
 Errors:
 
 - 400 `invalid input` or `stack not enabled for challenge`
-- 401 `invalid token` or `missing authorization` or `invalid authorization`
+- 401 `invalid token` or `missing access_token cookie` or `invalid token`
 - 403 `user blocked` or `challenge locked`
 - 404 `challenge not found`
 - 409 `stack limit reached` or `challenge already solved`
@@ -105,7 +105,7 @@ Errors:
 Headers
 
 ```
-Authorization: Bearer <access_token>
+Cookie: access_token=<jwt>
 ```
 
 Response 200
@@ -134,7 +134,7 @@ Response 200
 
 Errors:
 
-- 401 `invalid token` or `missing authorization` or `invalid authorization`
+- 401 `invalid token` or `missing access_token cookie` or `invalid token`
 - 404 `stack not found`
 - 503 `stack feature disabled` or `stack provisioner unavailable`
 
@@ -151,7 +151,7 @@ Notes:
 Headers
 
 ```
-Authorization: Bearer <access_token>
+Cookie: access_token=<jwt>
 ```
 
 Response 200
@@ -164,7 +164,7 @@ Response 200
 
 Errors:
 
-- 401 `invalid token` or `missing authorization` or `invalid authorization`
+- 401 `invalid token` or `missing access_token cookie` or `invalid token`
 - 404 `stack not found`
 - 503 `stack feature disabled` or `stack provisioner unavailable`
 

--- a/docs/docs/stacks.md
+++ b/docs/docs/stacks.md
@@ -3,6 +3,10 @@ title: Stacks
 nav_order: 8
 ---
 
+Notes:
+
+- For authenticated `POST`, `PUT`, `PATCH`, and `DELETE` requests, send both `csrf_token` cookie and matching `X-CSRF-Token` header.
+
 ## List My Stacks
 
 `GET /api/stacks`
@@ -43,7 +47,7 @@ Response 200
 
 Errors:
 
-- 401 `invalid token` or `missing access_token cookie` or `invalid token`
+- 401 `invalid token` or `missing access_token cookie`
 - 503 `stack feature disabled`
 
 Notes:
@@ -89,7 +93,7 @@ Response 201
 Errors:
 
 - 400 `invalid input` or `stack not enabled for challenge`
-- 401 `invalid token` or `missing access_token cookie` or `invalid token`
+- 401 `invalid token` or `missing access_token cookie`
 - 403 `user blocked` or `challenge locked`
 - 404 `challenge not found`
 - 409 `stack limit reached` or `challenge already solved`
@@ -134,7 +138,7 @@ Response 200
 
 Errors:
 
-- 401 `invalid token` or `missing access_token cookie` or `invalid token`
+- 401 `invalid token` or `missing access_token cookie`
 - 404 `stack not found`
 - 503 `stack feature disabled` or `stack provisioner unavailable`
 
@@ -164,7 +168,6 @@ Response 200
 
 Errors:
 
-- 401 `invalid token` or `missing access_token cookie` or `invalid token`
+- 401 `invalid token` or `missing access_token cookie`
 - 404 `stack not found`
 - 503 `stack feature disabled` or `stack provisioner unavailable`
-

--- a/docs/docs/users.md
+++ b/docs/docs/users.md
@@ -10,7 +10,7 @@ nav_order: 3
 Headers
 
 ```
-Authorization: Bearer <access_token>
+Cookie: access_token=<jwt>
 ```
 
 Response 200
@@ -33,7 +33,7 @@ Response 200
 
 Errors:
 
-- 401 `invalid token` or `missing authorization` or `invalid authorization`
+- 401 `invalid token` or `missing access_token cookie` or `invalid token`
 
 ---
 
@@ -44,7 +44,7 @@ Errors:
 Headers
 
 ```
-Authorization: Bearer <access_token>
+Cookie: access_token=<jwt>
 ```
 
 Request
@@ -78,7 +78,7 @@ Response 200
 Errors:
 
 - 400 `invalid input`
-- 401 `invalid token` or `missing authorization` or `invalid authorization`
+- 401 `invalid token` or `missing access_token cookie` or `invalid token`
 - 403 `user blocked`
 
 ---

--- a/docs/docs/users.md
+++ b/docs/docs/users.md
@@ -3,6 +3,10 @@ title: Users
 nav_order: 3
 ---
 
+Notes:
+
+- For authenticated `POST`, `PUT`, `PATCH`, and `DELETE` requests, send both `csrf_token` cookie and matching `X-CSRF-Token` header.
+
 ## Me
 
 `GET /api/me`
@@ -33,7 +37,7 @@ Response 200
 
 Errors:
 
-- 401 `invalid token` or `missing access_token cookie` or `invalid token`
+- 401 `invalid token` or `missing access_token cookie`
 
 ---
 
@@ -78,7 +82,7 @@ Response 200
 Errors:
 
 - 400 `invalid input`
-- 401 `invalid token` or `missing access_token cookie` or `invalid token`
+- 401 `invalid token` or `missing access_token cookie`
 - 403 `user blocked`
 
 ---

--- a/docs/docs/writeups.md
+++ b/docs/docs/writeups.md
@@ -113,7 +113,7 @@ Errors:
 Headers
 
 ```
-Authorization: Bearer <access_token>
+Cookie: access_token=<jwt>
 ```
 
 Request
@@ -170,7 +170,7 @@ Errors:
 Headers
 
 ```
-Authorization: Bearer <access_token>
+Cookie: access_token=<jwt>
 ```
 
 Request
@@ -221,7 +221,7 @@ Errors:
 Headers
 
 ```
-Authorization: Bearer <access_token>
+Cookie: access_token=<jwt>
 ```
 
 Response 200
@@ -249,7 +249,7 @@ Errors:
 Headers
 
 ```
-Authorization: Bearer <access_token>
+Cookie: access_token=<jwt>
 ```
 
 Query parameters:

--- a/docs/docs/writeups.md
+++ b/docs/docs/writeups.md
@@ -3,6 +3,10 @@ title: Writeups
 nav_order: 10
 ---
 
+Notes:
+
+- For authenticated `POST`, `PUT`, `PATCH`, and `DELETE` requests, send both `csrf_token` cookie and matching `X-CSRF-Token` header.
+
 ## List Challenge Writeups
 
 `GET /api/challenges/{id}/writeups`

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -113,10 +113,6 @@ const App = () => {
     }
 
     const loadSession = async () => {
-        if (!auth.accessToken) {
-            setBooting(false)
-            return
-        }
         try {
             const user = await api.me()
             setAuthUser(user)

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -171,11 +171,15 @@ export const createApi = ({ setAuthUser, clearAuth, translate }: ApiDeps) => {
             ?.slice(encoded.length)
     }
 
-    const buildHeaders = () => {
+    const buildHeaders = (method: string) => {
         const headers: Record<string, string> = { Accept: 'application/json' }
 
-        const csrfToken = getCookie('csrf_token')
-        if (csrfToken) headers['X-CSRF-Token'] = csrfToken
+        const upper = method.toUpperCase()
+        const needsCSRF = upper === 'POST' || upper === 'PUT' || upper === 'PATCH' || upper === 'DELETE'
+        if (needsCSRF) {
+            const csrfToken = getCookie('csrf_token')
+            if (csrfToken) headers['X-CSRF-Token'] = csrfToken
+        }
 
         return headers
     }
@@ -183,10 +187,7 @@ export const createApi = ({ setAuthUser, clearAuth, translate }: ApiDeps) => {
     const refreshToken = async () => {
         const response = await fetch(`${API_BASE}/api/auth/refresh`, {
             method: 'POST',
-            headers: {
-                Accept: 'application/json',
-                ...(getCookie('csrf_token') ? { 'X-CSRF-Token': getCookie('csrf_token') as string } : {}),
-            },
+            headers: buildHeaders('POST'),
             credentials: 'include',
         })
 
@@ -197,10 +198,10 @@ export const createApi = ({ setAuthUser, clearAuth, translate }: ApiDeps) => {
             throw new ApiError(data?.error ?? translate('errors.invalidCredentials'), response.status, data?.details, extractRateLimit(response, data))
         }
 
-		return 'ok'
+        return 'ok'
     }
 
-	let refreshInFlight: Promise<string> | null = null
+    let refreshInFlight: Promise<string> | null = null
 
     const getFreshToken = async () => {
         if (refreshInFlight) return refreshInFlight
@@ -230,20 +231,20 @@ export const createApi = ({ setAuthUser, clearAuth, translate }: ApiDeps) => {
             noCache?: boolean
         } = {},
     ): Promise<T> => {
-		const headers = buildHeaders()
+        const headers = buildHeaders(method)
         if (body !== undefined) headers['Content-Type'] = 'application/json'
         if (noCache) {
             headers['Cache-Control'] = 'no-cache'
             headers.Pragma = 'no-cache'
         }
 
-		const response = await fetch(`${API_BASE}${path}`, {
-			method,
-			headers,
-			body: body !== undefined ? JSON.stringify(body) : undefined,
-			credentials: 'include',
-			cache: noCache ? 'no-store' : 'default',
-		})
+        const response = await fetch(`${API_BASE}${path}`, {
+            method,
+            headers,
+            body: body !== undefined ? JSON.stringify(body) : undefined,
+            credentials: 'include',
+            cache: noCache ? 'no-store' : 'default',
+        })
 
         if (response.ok) {
             if (response.status === 204) return null as T
@@ -253,21 +254,21 @@ export const createApi = ({ setAuthUser, clearAuth, translate }: ApiDeps) => {
 
         if (response.status === 401 && auth && retryOnAuth) {
             try {
-				await getFreshToken()
-				const retryHeaders = buildHeaders()
+                await getFreshToken()
+                const retryHeaders = buildHeaders(method)
                 if (body !== undefined) retryHeaders['Content-Type'] = 'application/json'
                 if (noCache) {
                     retryHeaders['Cache-Control'] = 'no-cache'
                     retryHeaders.Pragma = 'no-cache'
                 }
 
-				const retryResponse = await fetch(`${API_BASE}${path}`, {
-					method,
-					headers: retryHeaders,
-					body: body !== undefined ? JSON.stringify(body) : undefined,
-					credentials: 'include',
-					cache: noCache ? 'no-store' : 'default',
-				})
+                const retryResponse = await fetch(`${API_BASE}${path}`, {
+                    method,
+                    headers: retryHeaders,
+                    body: body !== undefined ? JSON.stringify(body) : undefined,
+                    credentials: 'include',
+                    cache: noCache ? 'no-store' : 'default',
+                })
 
                 if (retryResponse.ok) {
                     if (retryResponse.status === 204) return null as T

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -40,6 +40,7 @@ import type {
 } from './types'
 
 const API_BASE = import.meta.env.VITE_API_BASE ?? 'http://localhost:8080'
+const CSRF_TOKEN_HEADER = 'X-CSRF-Token'
 
 export interface ApiErrorDetail {
     field: string
@@ -178,7 +179,7 @@ export const createApi = ({ setAuthUser, clearAuth, translate }: ApiDeps) => {
         const needsCSRF = upper === 'POST' || upper === 'PUT' || upper === 'PATCH' || upper === 'DELETE'
         if (needsCSRF) {
             const csrfToken = getCookie('csrf_token')
-            if (csrfToken) headers['X-CSRF-Token'] = csrfToken
+            if (csrfToken) headers[CSRF_TOKEN_HEADER] = csrfToken
         }
 
         return headers

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -38,7 +38,6 @@ import type {
     Writeup,
     WriteupDetailResponse,
 } from './types'
-import type { AuthState } from './auth'
 
 const API_BASE = import.meta.env.VITE_API_BASE ?? 'http://localhost:8080'
 
@@ -67,8 +66,6 @@ export class ApiError extends Error {
 }
 
 interface ApiDeps {
-    getAuth: () => AuthState
-    setAuthTokens: (accessToken: string, refreshToken: string) => void
     setAuthUser: (user: AuthUser | null) => void
     clearAuth: () => void
     translate: (key: string, vars?: Record<string, string | number>) => string
@@ -95,7 +92,7 @@ const extractRateLimit = (response: Response, data: any): RateLimitInfo | undefi
     return undefined
 }
 
-export const createApi = ({ getAuth, setAuthTokens, setAuthUser, clearAuth, translate }: ApiDeps) => {
+export const createApi = ({ setAuthUser, clearAuth, translate }: ApiDeps) => {
     const defaultPagination = (): PaginationMeta => ({
         page: 1,
         page_size: 20,
@@ -165,28 +162,32 @@ export const createApi = ({ getAuth, setAuthTokens, setAuthUser, clearAuth, tran
         return query ? `${path}?${query}` : path
     }
 
-    const buildHeaders = (withAuth: boolean, tokenOverride?: string) => {
+    const getCookie = (name: string) => {
+        const encoded = `${name}=`
+        return document.cookie
+            .split(';')
+            .map((part) => part.trim())
+            .find((part) => part.startsWith(encoded))
+            ?.slice(encoded.length)
+    }
+
+    const buildHeaders = () => {
         const headers: Record<string, string> = { Accept: 'application/json' }
 
-        if (withAuth) {
-            const token = tokenOverride ?? getAuth().accessToken
-            if (token) headers.Authorization = `Bearer ${token}`
-        }
+        const csrfToken = getCookie('csrf_token')
+        if (csrfToken) headers['X-CSRF-Token'] = csrfToken
 
         return headers
     }
 
     const refreshToken = async () => {
-        const refreshTokenValue = getAuth().refreshToken
-        if (!refreshTokenValue) throw new ApiError(translate('errors.missingRefreshToken'), 401)
-
         const response = await fetch(`${API_BASE}/api/auth/refresh`, {
             method: 'POST',
             headers: {
-                'Content-Type': 'application/json',
                 Accept: 'application/json',
+                ...(getCookie('csrf_token') ? { 'X-CSRF-Token': getCookie('csrf_token') as string } : {}),
             },
-            body: JSON.stringify({ refresh_token: refreshTokenValue }),
+            credentials: 'include',
         })
 
         if (!response.ok) {
@@ -196,13 +197,10 @@ export const createApi = ({ getAuth, setAuthTokens, setAuthUser, clearAuth, tran
             throw new ApiError(data?.error ?? translate('errors.invalidCredentials'), response.status, data?.details, extractRateLimit(response, data))
         }
 
-        const data = await response.json()
-        setAuthTokens(data.access_token, data.refresh_token)
-
-        return data.access_token as string
+		return 'ok'
     }
 
-    let refreshInFlight: Promise<string> | null = null
+	let refreshInFlight: Promise<string> | null = null
 
     const getFreshToken = async () => {
         if (refreshInFlight) return refreshInFlight
@@ -232,19 +230,20 @@ export const createApi = ({ getAuth, setAuthTokens, setAuthUser, clearAuth, tran
             noCache?: boolean
         } = {},
     ): Promise<T> => {
-        const headers = buildHeaders(auth)
+		const headers = buildHeaders()
         if (body !== undefined) headers['Content-Type'] = 'application/json'
         if (noCache) {
             headers['Cache-Control'] = 'no-cache'
             headers.Pragma = 'no-cache'
         }
 
-        const response = await fetch(`${API_BASE}${path}`, {
-            method,
-            headers,
-            body: body !== undefined ? JSON.stringify(body) : undefined,
-            cache: noCache ? 'no-store' : 'default',
-        })
+		const response = await fetch(`${API_BASE}${path}`, {
+			method,
+			headers,
+			body: body !== undefined ? JSON.stringify(body) : undefined,
+			credentials: 'include',
+			cache: noCache ? 'no-store' : 'default',
+		})
 
         if (response.ok) {
             if (response.status === 204) return null as T
@@ -254,20 +253,21 @@ export const createApi = ({ getAuth, setAuthTokens, setAuthUser, clearAuth, tran
 
         if (response.status === 401 && auth && retryOnAuth) {
             try {
-                const newToken = await getFreshToken()
-                const retryHeaders = buildHeaders(true, newToken)
+				await getFreshToken()
+				const retryHeaders = buildHeaders()
                 if (body !== undefined) retryHeaders['Content-Type'] = 'application/json'
                 if (noCache) {
                     retryHeaders['Cache-Control'] = 'no-cache'
                     retryHeaders.Pragma = 'no-cache'
                 }
 
-                const retryResponse = await fetch(`${API_BASE}${path}`, {
-                    method,
-                    headers: retryHeaders,
-                    body: body !== undefined ? JSON.stringify(body) : undefined,
-                    cache: noCache ? 'no-store' : 'default',
-                })
+				const retryResponse = await fetch(`${API_BASE}${path}`, {
+					method,
+					headers: retryHeaders,
+					body: body !== undefined ? JSON.stringify(body) : undefined,
+					credentials: 'include',
+					cache: noCache ? 'no-store' : 'default',
+				})
 
                 if (retryResponse.ok) {
                     if (retryResponse.status === 204) return null as T
@@ -292,17 +292,11 @@ export const createApi = ({ getAuth, setAuthTokens, setAuthUser, clearAuth, tran
         register: (payload: RegisterPayload) => request<RegisterResponse>(`/api/auth/register`, { method: 'POST', body: payload }),
         login: async (payload: LoginPayload) => {
             const data = await request<AuthResponse>(`/api/auth/login`, { method: 'POST', body: payload })
-            setAuthTokens(data.access_token, data.refresh_token)
             setAuthUser(data.user)
             return data
         },
         logout: async () => {
-            const refreshTokenValue = getAuth().refreshToken
-            if (!refreshTokenValue) {
-                clearAuth()
-                return
-            }
-            await request(`/api/auth/logout`, { method: 'POST', body: { refresh_token: refreshTokenValue } })
+            await request(`/api/auth/logout`, { method: 'POST' })
             clearAuth()
         },
         me: () => request<AuthUser>(`/api/me`, { auth: true }),

--- a/frontend/src/lib/auth.tsx
+++ b/frontend/src/lib/auth.tsx
@@ -2,55 +2,27 @@ import { createContext, useCallback, useContext, useEffect, useMemo, useRef, use
 import type { AuthUser } from './types'
 
 export interface AuthState {
-    accessToken: string | null
-    refreshToken: string | null
     user: AuthUser | null
 }
 
 interface AuthContextValue {
     state: AuthState
     getAuth: () => AuthState
-    setAuthTokens: (accessToken: string, refreshToken: string) => void
     setAuthUser: (user: AuthUser | null) => void
     clearAuth: () => void
 }
 
-const STORAGE_KEY = 'wargame.auth'
-
-const emptyAuth = (): AuthState => ({ accessToken: null, refreshToken: null, user: null })
-
-const loadAuth = (): AuthState => {
-    if (typeof localStorage === 'undefined') return emptyAuth()
-
-    try {
-        const raw = localStorage.getItem(STORAGE_KEY)
-        if (!raw) return emptyAuth()
-        return JSON.parse(raw) as AuthState
-    } catch {
-        return emptyAuth()
-    }
-}
-
-const persistAuth = (state: AuthState) => {
-    if (typeof localStorage !== 'undefined') {
-        localStorage.setItem(STORAGE_KEY, JSON.stringify(state))
-    }
-}
+const emptyAuth = (): AuthState => ({ user: null })
 
 const AuthContext = createContext<AuthContextValue | null>(null)
 
 export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
-    const [state, setState] = useState<AuthState>(() => loadAuth())
+    const [state, setState] = useState<AuthState>(emptyAuth)
     const stateRef = useRef(state)
 
     useEffect(() => {
         stateRef.current = state
-        persistAuth(state)
     }, [state])
-
-    const setAuthTokens = useCallback((accessToken: string, refreshToken: string) => {
-        setState((prev) => ({ ...prev, accessToken, refreshToken }))
-    }, [])
 
     const setAuthUser = useCallback((user: AuthUser | null) => {
         setState((prev) => ({ ...prev, user }))
@@ -64,11 +36,10 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
         () => ({
             state,
             getAuth: () => stateRef.current,
-            setAuthTokens,
             setAuthUser,
             clearAuth,
         }),
-        [state, setAuthTokens, setAuthUser, clearAuth],
+        [state, setAuthUser, clearAuth],
     )
 
     return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -30,8 +30,6 @@ export interface LoginPayload {
 }
 
 export interface AuthResponse {
-    access_token: string
-    refresh_token: string
     user: AuthUser
 }
 

--- a/frontend/src/lib/useApi.ts
+++ b/frontend/src/lib/useApi.ts
@@ -4,18 +4,16 @@ import { useAuth } from './auth'
 import { useT } from './i18n'
 
 export const useApi = () => {
-    const { getAuth, setAuthTokens, setAuthUser, clearAuth } = useAuth()
+    const { setAuthUser, clearAuth } = useAuth()
     const t = useT()
 
     return useMemo(
         () =>
             createApi({
-                getAuth,
-                setAuthTokens,
                 setAuthUser,
                 clearAuth,
                 translate: t,
             }),
-        [getAuth, setAuthTokens, setAuthUser, clearAuth, t],
+        [setAuthUser, clearAuth, t],
     )
 }

--- a/frontend/src/routes/WriteupEditor.tsx
+++ b/frontend/src/routes/WriteupEditor.tsx
@@ -56,7 +56,7 @@ const WriteupEditor = ({ routeParams = {} }: RouteProps) => {
 
     useEffect(() => {
         void loadWriteup()
-    }, [challengeId])
+    }, [challengeId, auth.user?.id])
 
     const saveWriteup = async () => {
         if (!challengeId || !auth.user || saving) return

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	ShutdownTimeout time.Duration
 	AutoMigrate     bool
 	BcryptCost      int
+	CookieDomain    string
 
 	DB       DBConfig
 	Redis    RedisConfig
@@ -250,6 +251,7 @@ func Load() (Config, error) {
 		ShutdownTimeout: shutdownTimeout,
 		AutoMigrate:     autoMigrate,
 		BcryptCost:      bcryptCost,
+		CookieDomain:    getEnv("COOKIE_DOMAIN", ""),
 		DB: DBConfig{
 			Host:            getEnv("DB_HOST", "localhost"),
 			Port:            dbPort,

--- a/internal/http/handlers/auth_cookie.go
+++ b/internal/http/handlers/auth_cookie.go
@@ -79,7 +79,7 @@ func setCookie(ctx *gin.Context, cfg config.Config, name, value string, maxAge i
 	}
 
 	ctx.SetSameSite(sameSite)
-	ctx.SetCookie(name, value, maxAge, "/", "", secure, httpOnly)
+	ctx.SetCookie(name, value, maxAge, "/", cfg.CookieDomain, secure, httpOnly)
 }
 
 func randomTokenHex(bytesLen int) (string, error) {

--- a/internal/http/handlers/auth_cookie.go
+++ b/internal/http/handlers/auth_cookie.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"net/http"
 
 	"wargame/internal/config"
@@ -17,13 +18,21 @@ const (
 	csrfTokenHeaderName    = "X-CSRF-Token"
 )
 
-func setAuthCookies(ctx *gin.Context, cfg config.Config, accessToken, refreshToken string) {
+var errCSRFTokenGeneration = errors.New("failed to generate csrf token")
+
+var randRead = rand.Read
+
+func setAuthCookies(ctx *gin.Context, cfg config.Config, accessToken, refreshToken string) error {
 	setCookie(ctx, cfg, accessTokenCookieName, accessToken, int(cfg.JWT.AccessTTL.Seconds()), true)
 	setCookie(ctx, cfg, refreshTokenCookieName, refreshToken, int(cfg.JWT.RefreshTTL.Seconds()), true)
 
 	csrfToken, ok := currentCSRFToken(ctx)
 	if !ok {
-		csrfToken = randomTokenHex(32)
+		var err error
+		csrfToken, err = randomTokenHex(32)
+		if err != nil {
+			return err
+		}
 	}
 
 	maxAge := max(int(cfg.JWT.RefreshTTL.Seconds()), int(cfg.JWT.AccessTTL.Seconds()))
@@ -32,6 +41,7 @@ func setAuthCookies(ctx *gin.Context, cfg config.Config, accessToken, refreshTok
 	ctx.Header(csrfTokenHeaderName, csrfToken)
 	ctx.Header("Cache-Control", "no-store")
 	ctx.Header("Pragma", "no-cache")
+	return nil
 }
 
 func clearAuthCookies(ctx *gin.Context, cfg config.Config) {
@@ -67,11 +77,11 @@ func setCookie(ctx *gin.Context, cfg config.Config, name, value string, maxAge i
 	ctx.SetCookie(name, value, maxAge, "/", "", secure, httpOnly)
 }
 
-func randomTokenHex(bytesLen int) string {
+func randomTokenHex(bytesLen int) (string, error) {
 	b := make([]byte, bytesLen)
-	if _, err := rand.Read(b); err != nil {
-		return "fallback-csrf-token"
+	if _, err := randRead(b); err != nil {
+		return "", errCSRFTokenGeneration
 	}
 
-	return hex.EncodeToString(b)
+	return hex.EncodeToString(b), nil
 }

--- a/internal/http/handlers/auth_cookie.go
+++ b/internal/http/handlers/auth_cookie.go
@@ -73,6 +73,11 @@ func currentCSRFToken(ctx *gin.Context) (string, bool) {
 func setCookie(ctx *gin.Context, cfg config.Config, name, value string, maxAge int, httpOnly bool) {
 	secure := cfg.AppEnv == "production"
 	sameSite := http.SameSiteLaxMode
+	if cfg.AppEnv == "local" {
+		sameSite = http.SameSiteNoneMode
+		secure = true
+	}
+
 	ctx.SetSameSite(sameSite)
 	ctx.SetCookie(name, value, maxAge, "/", "", secure, httpOnly)
 }

--- a/internal/http/handlers/auth_cookie.go
+++ b/internal/http/handlers/auth_cookie.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"net/http"
+	"strings"
 
 	"wargame/internal/config"
 
@@ -74,12 +75,40 @@ func setCookie(ctx *gin.Context, cfg config.Config, name, value string, maxAge i
 	secure := cfg.AppEnv == "production"
 	sameSite := http.SameSiteLaxMode
 	if cfg.AppEnv == "local" {
-		sameSite = http.SameSiteNoneMode
-		secure = true
+		if isHTTPSRequest(ctx.Request) {
+			sameSite = http.SameSiteNoneMode
+			secure = true
+		} else {
+			sameSite = http.SameSiteLaxMode
+			secure = false
+		}
 	}
 
 	ctx.SetSameSite(sameSite)
 	ctx.SetCookie(name, value, maxAge, "/", cfg.CookieDomain, secure, httpOnly)
+}
+
+func isHTTPSRequest(req *http.Request) bool {
+	if req == nil {
+		return false
+	}
+
+	if req.TLS != nil {
+		return true
+	}
+
+	v := strings.ToLower(strings.TrimSpace(req.Header.Get("X-Forwarded-Proto")))
+	if v == "" {
+		return false
+	}
+
+	for _, p := range strings.Split(v, ",") {
+		if strings.TrimSpace(p) == "https" {
+			return true
+		}
+	}
+
+	return false
 }
 
 func randomTokenHex(bytesLen int) (string, error) {

--- a/internal/http/handlers/auth_cookie.go
+++ b/internal/http/handlers/auth_cookie.go
@@ -1,0 +1,77 @@
+package handlers
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"net/http"
+
+	"wargame/internal/config"
+
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	accessTokenCookieName  = "access_token"
+	refreshTokenCookieName = "refresh_token"
+	csrfTokenCookieName    = "csrf_token"
+	csrfTokenHeaderName    = "X-CSRF-Token"
+)
+
+func setAuthCookies(ctx *gin.Context, cfg config.Config, accessToken, refreshToken string) {
+	setCookie(ctx, cfg, accessTokenCookieName, accessToken, int(cfg.JWT.AccessTTL.Seconds()), true)
+	setCookie(ctx, cfg, refreshTokenCookieName, refreshToken, int(cfg.JWT.RefreshTTL.Seconds()), true)
+
+	csrfToken, ok := currentCSRFToken(ctx)
+	if !ok {
+		csrfToken = randomTokenHex(32)
+	}
+
+	maxAge := max(int(cfg.JWT.RefreshTTL.Seconds()), int(cfg.JWT.AccessTTL.Seconds()))
+
+	setCookie(ctx, cfg, csrfTokenCookieName, csrfToken, maxAge, false)
+	ctx.Header(csrfTokenHeaderName, csrfToken)
+	ctx.Header("Cache-Control", "no-store")
+	ctx.Header("Pragma", "no-cache")
+}
+
+func clearAuthCookies(ctx *gin.Context, cfg config.Config) {
+	setCookie(ctx, cfg, accessTokenCookieName, "", -1, true)
+	setCookie(ctx, cfg, refreshTokenCookieName, "", -1, true)
+	setCookie(ctx, cfg, csrfTokenCookieName, "", -1, false)
+	ctx.Header("Cache-Control", "no-store")
+	ctx.Header("Pragma", "no-cache")
+}
+
+func currentRefreshToken(ctx *gin.Context) (string, bool) {
+	v, err := ctx.Cookie(refreshTokenCookieName)
+	if err != nil || v == "" {
+		return "", false
+	}
+
+	return v, true
+}
+
+func currentCSRFToken(ctx *gin.Context) (string, bool) {
+	v, err := ctx.Cookie(csrfTokenCookieName)
+	if err != nil || v == "" {
+		return "", false
+	}
+
+	return v, true
+}
+
+func setCookie(ctx *gin.Context, cfg config.Config, name, value string, maxAge int, httpOnly bool) {
+	secure := cfg.AppEnv == "production"
+	sameSite := http.SameSiteLaxMode
+	ctx.SetSameSite(sameSite)
+	ctx.SetCookie(name, value, maxAge, "/", "", secure, httpOnly)
+}
+
+func randomTokenHex(bytesLen int) string {
+	b := make([]byte, bytesLen)
+	if _, err := rand.Read(b); err != nil {
+		return "fallback-csrf-token"
+	}
+
+	return hex.EncodeToString(b)
+}

--- a/internal/http/handlers/auth_cookie_test.go
+++ b/internal/http/handlers/auth_cookie_test.go
@@ -195,19 +195,36 @@ func TestSetCookieLocalHTTPSUsesSameSiteNoneAndSecure(t *testing.T) {
 	}
 }
 
-func TestSetCookieLocalHTTPUsesSameSiteNoneWithSecure(t *testing.T) {
+func TestSetCookieLocalHTTPUsesSameSiteLaxWithoutSecure(t *testing.T) {
 	ctx, rec := newCookieTestContext(t)
 	cfg := testConfig("local", time.Hour, time.Hour)
 
 	setCookie(ctx, cfg, "x", "y", 10, true)
 
 	cookie := cookieHeaderByPrefix(rec.Header().Values("Set-Cookie"), "x=")
+	if strings.Contains(cookie, "Secure") {
+		t.Fatalf("expected non-secure cookie for local http, got %q", cookie)
+	}
+
+	if !strings.Contains(cookie, "SameSite=Lax") {
+		t.Fatalf("expected SameSite=Lax for local http, got %q", cookie)
+	}
+}
+
+func TestSetCookieLocalForwardedHTTPSUsesSameSiteNoneAndSecure(t *testing.T) {
+	ctx, rec := newCookieTestContext(t)
+	cfg := testConfig("local", time.Hour, time.Hour)
+	ctx.Request.Header.Set("X-Forwarded-Proto", "https")
+
+	setCookie(ctx, cfg, "x", "y", 10, true)
+
+	cookie := cookieHeaderByPrefix(rec.Header().Values("Set-Cookie"), "x=")
 	if !strings.Contains(cookie, "Secure") {
-		t.Fatalf("expected secure cookie for local mode, got %q", cookie)
+		t.Fatalf("expected secure cookie for forwarded https, got %q", cookie)
 	}
 
 	if !strings.Contains(cookie, "SameSite=None") {
-		t.Fatalf("expected SameSite=None for local http, got %q", cookie)
+		t.Fatalf("expected SameSite=None for forwarded https, got %q", cookie)
 	}
 }
 

--- a/internal/http/handlers/auth_cookie_test.go
+++ b/internal/http/handlers/auth_cookie_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"crypto/tls"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -174,6 +175,39 @@ func TestSetCookieProductionSecureFlag(t *testing.T) {
 
 	if !strings.Contains(cookie, "HttpOnly") {
 		t.Fatalf("expected httponly cookie, got %q", cookie)
+	}
+}
+
+func TestSetCookieLocalHTTPSUsesSameSiteNoneAndSecure(t *testing.T) {
+	ctx, rec := newCookieTestContext(t)
+	cfg := testConfig("local", time.Hour, time.Hour)
+	ctx.Request.TLS = &tls.ConnectionState{}
+
+	setCookie(ctx, cfg, "x", "y", 10, true)
+
+	cookie := cookieHeaderByPrefix(rec.Header().Values("Set-Cookie"), "x=")
+	if !strings.Contains(cookie, "Secure") {
+		t.Fatalf("expected secure cookie for local https, got %q", cookie)
+	}
+
+	if !strings.Contains(cookie, "SameSite=None") {
+		t.Fatalf("expected SameSite=None for local https, got %q", cookie)
+	}
+}
+
+func TestSetCookieLocalHTTPUsesSameSiteNoneWithSecure(t *testing.T) {
+	ctx, rec := newCookieTestContext(t)
+	cfg := testConfig("local", time.Hour, time.Hour)
+
+	setCookie(ctx, cfg, "x", "y", 10, true)
+
+	cookie := cookieHeaderByPrefix(rec.Header().Values("Set-Cookie"), "x=")
+	if !strings.Contains(cookie, "Secure") {
+		t.Fatalf("expected secure cookie for local mode, got %q", cookie)
+	}
+
+	if !strings.Contains(cookie, "SameSite=None") {
+		t.Fatalf("expected SameSite=None for local http, got %q", cookie)
 	}
 }
 

--- a/internal/http/handlers/auth_cookie_test.go
+++ b/internal/http/handlers/auth_cookie_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -46,7 +47,9 @@ func TestSetAuthCookiesGeneratesCookiesAndHeaders(t *testing.T) {
 	ctx, rec := newCookieTestContext(t)
 	cfg := testConfig("local", time.Hour, 2*time.Hour)
 
-	setAuthCookies(ctx, cfg, "access-abc", "refresh-def")
+	if err := setAuthCookies(ctx, cfg, "access-abc", "refresh-def"); err != nil {
+		t.Fatalf("setAuthCookies: %v", err)
+	}
 
 	cookies := rec.Header().Values("Set-Cookie")
 	if len(cookies) != 3 {
@@ -87,7 +90,9 @@ func TestSetAuthCookiesReusesExistingCSRFToken(t *testing.T) {
 	cfg := testConfig("local", 2*time.Hour, time.Hour)
 
 	ctx.Request.AddCookie(&http.Cookie{Name: csrfTokenCookieName, Value: "persist-csrf"})
-	setAuthCookies(ctx, cfg, "access", "refresh")
+	if err := setAuthCookies(ctx, cfg, "access", "refresh"); err != nil {
+		t.Fatalf("setAuthCookies: %v", err)
+	}
 
 	csrfHeader := rec.Header().Get(csrfTokenHeaderName)
 	if csrfHeader != "persist-csrf" {
@@ -173,8 +178,25 @@ func TestSetCookieProductionSecureFlag(t *testing.T) {
 }
 
 func TestRandomTokenHex_Length(t *testing.T) {
-	tok := randomTokenHex(32)
+	tok, err := randomTokenHex(32)
+	if err != nil {
+		t.Fatalf("randomTokenHex: %v", err)
+	}
 	if len(tok) != 64 {
 		t.Fatalf("expected hex length 64, got %d", len(tok))
+	}
+}
+
+func TestSetAuthCookies_ReturnsErrorWhenRandomFails(t *testing.T) {
+	ctx, _ := newCookieTestContext(t)
+	cfg := testConfig("local", time.Hour, 2*time.Hour)
+
+	prev := randRead
+	randRead = func([]byte) (int, error) { return 0, errors.New("rng down") }
+	t.Cleanup(func() { randRead = prev })
+
+	err := setAuthCookies(ctx, cfg, "access", "refresh")
+	if !errors.Is(err, errCSRFTokenGeneration) {
+		t.Fatalf("expected errCSRFTokenGeneration, got %v", err)
 	}
 }

--- a/internal/http/handlers/auth_cookie_test.go
+++ b/internal/http/handlers/auth_cookie_test.go
@@ -1,0 +1,180 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"wargame/internal/config"
+
+	"github.com/gin-gonic/gin"
+)
+
+func newCookieTestContext(t *testing.T) (*gin.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+
+	return ctx, rec
+}
+
+func testConfig(appEnv string, accessTTL, refreshTTL time.Duration) config.Config {
+	return config.Config{
+		AppEnv: appEnv,
+		JWT: config.JWTConfig{
+			AccessTTL:  accessTTL,
+			RefreshTTL: refreshTTL,
+		},
+	}
+}
+
+func cookieHeaderByPrefix(values []string, prefix string) string {
+	for _, v := range values {
+		if strings.HasPrefix(v, prefix) {
+			return v
+		}
+	}
+
+	return ""
+}
+
+func TestSetAuthCookiesGeneratesCookiesAndHeaders(t *testing.T) {
+	ctx, rec := newCookieTestContext(t)
+	cfg := testConfig("local", time.Hour, 2*time.Hour)
+
+	setAuthCookies(ctx, cfg, "access-abc", "refresh-def")
+
+	cookies := rec.Header().Values("Set-Cookie")
+	if len(cookies) != 3 {
+		t.Fatalf("expected 3 cookies, got %d", len(cookies))
+	}
+
+	access := cookieHeaderByPrefix(cookies, accessTokenCookieName+"=")
+	if access == "" || !strings.Contains(access, "access-abc") || !strings.Contains(access, "HttpOnly") {
+		t.Fatalf("unexpected access cookie: %q", access)
+	}
+
+	refresh := cookieHeaderByPrefix(cookies, refreshTokenCookieName+"=")
+	if refresh == "" || !strings.Contains(refresh, "refresh-def") || !strings.Contains(refresh, "HttpOnly") {
+		t.Fatalf("unexpected refresh cookie: %q", refresh)
+	}
+
+	csrf := cookieHeaderByPrefix(cookies, csrfTokenCookieName+"=")
+	if csrf == "" || strings.Contains(csrf, "HttpOnly") {
+		t.Fatalf("unexpected csrf cookie: %q", csrf)
+	}
+
+	csrfHeader := rec.Header().Get(csrfTokenHeaderName)
+	if csrfHeader == "" {
+		t.Fatal("expected csrf response header")
+	}
+
+	if rec.Header().Get("Cache-Control") != "no-store" {
+		t.Fatalf("expected Cache-Control no-store, got %q", rec.Header().Get("Cache-Control"))
+	}
+
+	if rec.Header().Get("Pragma") != "no-cache" {
+		t.Fatalf("expected Pragma no-cache, got %q", rec.Header().Get("Pragma"))
+	}
+}
+
+func TestSetAuthCookiesReusesExistingCSRFToken(t *testing.T) {
+	ctx, rec := newCookieTestContext(t)
+	cfg := testConfig("local", 2*time.Hour, time.Hour)
+
+	ctx.Request.AddCookie(&http.Cookie{Name: csrfTokenCookieName, Value: "persist-csrf"})
+	setAuthCookies(ctx, cfg, "access", "refresh")
+
+	csrfHeader := rec.Header().Get(csrfTokenHeaderName)
+	if csrfHeader != "persist-csrf" {
+		t.Fatalf("expected existing csrf token, got %q", csrfHeader)
+	}
+
+	cookies := rec.Header().Values("Set-Cookie")
+	csrf := cookieHeaderByPrefix(cookies, csrfTokenCookieName+"=")
+	if !strings.Contains(csrf, "persist-csrf") {
+		t.Fatalf("expected persisted csrf cookie, got %q", csrf)
+	}
+
+	if !strings.Contains(csrf, "Max-Age=7200") {
+		t.Fatalf("expected csrf cookie max-age to use larger ttl, got %q", csrf)
+	}
+}
+
+func TestClearAuthCookies(t *testing.T) {
+	ctx, rec := newCookieTestContext(t)
+	cfg := testConfig("local", time.Hour, time.Hour)
+
+	clearAuthCookies(ctx, cfg)
+
+	cookies := rec.Header().Values("Set-Cookie")
+	if len(cookies) != 3 {
+		t.Fatalf("expected 3 cookies, got %d", len(cookies))
+	}
+
+	for _, name := range []string{accessTokenCookieName, refreshTokenCookieName, csrfTokenCookieName} {
+		v := cookieHeaderByPrefix(cookies, name+"=")
+		if v == "" || !strings.Contains(v, "Max-Age=0") {
+			t.Fatalf("expected clearing cookie for %s, got %q", name, v)
+		}
+	}
+}
+
+func TestCurrentTokenReaders(t *testing.T) {
+	t.Run("refresh missing", func(t *testing.T) {
+		ctx, _ := newCookieTestContext(t)
+		if v, ok := currentRefreshToken(ctx); ok || v != "" {
+			t.Fatalf("expected missing refresh token")
+		}
+	})
+
+	t.Run("refresh exists", func(t *testing.T) {
+		ctx, _ := newCookieTestContext(t)
+		ctx.Request.AddCookie(&http.Cookie{Name: refreshTokenCookieName, Value: "ref"})
+		if v, ok := currentRefreshToken(ctx); !ok || v != "ref" {
+			t.Fatalf("expected refresh token ref, got %q ok=%v", v, ok)
+		}
+	})
+
+	t.Run("csrf missing", func(t *testing.T) {
+		ctx, _ := newCookieTestContext(t)
+		if v, ok := currentCSRFToken(ctx); ok || v != "" {
+			t.Fatalf("expected missing csrf token")
+		}
+	})
+
+	t.Run("csrf exists", func(t *testing.T) {
+		ctx, _ := newCookieTestContext(t)
+		ctx.Request.AddCookie(&http.Cookie{Name: csrfTokenCookieName, Value: "csrf"})
+		if v, ok := currentCSRFToken(ctx); !ok || v != "csrf" {
+			t.Fatalf("expected csrf token csrf, got %q ok=%v", v, ok)
+		}
+	})
+}
+
+func TestSetCookieProductionSecureFlag(t *testing.T) {
+	ctx, rec := newCookieTestContext(t)
+	cfg := testConfig("production", time.Hour, time.Hour)
+
+	setCookie(ctx, cfg, "x", "y", 10, true)
+
+	cookie := cookieHeaderByPrefix(rec.Header().Values("Set-Cookie"), "x=")
+	if !strings.Contains(cookie, "Secure") {
+		t.Fatalf("expected secure cookie in production, got %q", cookie)
+	}
+
+	if !strings.Contains(cookie, "HttpOnly") {
+		t.Fatalf("expected httponly cookie, got %q", cookie)
+	}
+}
+
+func TestRandomTokenHex_Length(t *testing.T) {
+	tok := randomTokenHex(32)
+	if len(tok) != 64 {
+		t.Fatalf("expected hex length 64, got %d", len(tok))
+	}
+}

--- a/internal/http/handlers/handler.go
+++ b/internal/http/handlers/handler.go
@@ -264,7 +264,10 @@ func (h *Handler) Login(ctx *gin.Context) {
 		return
 	}
 
-	setAuthCookies(ctx, h.cfg, accessToken, refreshToken)
+	if err := setAuthCookies(ctx, h.cfg, accessToken, refreshToken); err != nil {
+		writeError(ctx, err)
+		return
+	}
 	stackCount, stackLimit, _ := h.stacks.UserStackSummary(ctx.Request.Context(), user.ID)
 	ctx.JSON(http.StatusOK, loginResponse{User: newUserMeResponse(user, stackCount, stackLimit)})
 }
@@ -282,7 +285,10 @@ func (h *Handler) Refresh(ctx *gin.Context) {
 		return
 	}
 
-	setAuthCookies(ctx, h.cfg, accessToken, refreshToken)
+	if err := setAuthCookies(ctx, h.cfg, accessToken, refreshToken); err != nil {
+		writeError(ctx, err)
+		return
+	}
 	ctx.JSON(http.StatusOK, refreshResponse{Status: "ok"})
 }
 

--- a/internal/http/handlers/handler.go
+++ b/internal/http/handlers/handler.go
@@ -192,17 +192,12 @@ func parseChallengeFilters(ctx *gin.Context) (challengeQueryFilters, bool) {
 }
 
 func (h *Handler) optionalUserID(ctx *gin.Context) int64 {
-	authHeader := ctx.GetHeader("Authorization")
-	if authHeader == "" {
+	token, err := ctx.Cookie("access_token")
+	if err != nil || token == "" {
 		return 0
 	}
 
-	parts := strings.SplitN(authHeader, " ", 2)
-	if len(parts) != 2 || !strings.EqualFold(parts[0], "Bearer") {
-		return 0
-	}
-
-	claims, err := auth.ParseToken(h.cfg.JWT, parts[1])
+	claims, err := auth.ParseToken(h.cfg.JWT, token)
 	if err != nil || claims.Type != auth.TokenTypeAccess {
 		return 0
 	}
@@ -269,38 +264,38 @@ func (h *Handler) Login(ctx *gin.Context) {
 		return
 	}
 
+	setAuthCookies(ctx, h.cfg, accessToken, refreshToken)
 	stackCount, stackLimit, _ := h.stacks.UserStackSummary(ctx.Request.Context(), user.ID)
-	ctx.JSON(http.StatusOK, loginResponse{AccessToken: accessToken, RefreshToken: refreshToken, User: newUserMeResponse(user, stackCount, stackLimit)})
+	ctx.JSON(http.StatusOK, loginResponse{User: newUserMeResponse(user, stackCount, stackLimit)})
 }
 
 func (h *Handler) Refresh(ctx *gin.Context) {
-	var req refreshRequest
-	if err := ctx.ShouldBindJSON(&req); err != nil {
-		writeBindError(ctx, err)
+	refreshTokenValue, ok := currentRefreshToken(ctx)
+	if !ok {
+		ctx.JSON(http.StatusUnauthorized, gin.H{"error": "invalid token"})
 		return
 	}
 
-	accessToken, refreshToken, err := h.auth.Refresh(ctx.Request.Context(), req.RefreshToken)
+	accessToken, refreshToken, err := h.auth.Refresh(ctx.Request.Context(), refreshTokenValue)
 	if err != nil {
 		writeError(ctx, err)
 		return
 	}
 
-	ctx.JSON(http.StatusOK, refreshResponse{AccessToken: accessToken, RefreshToken: refreshToken})
+	setAuthCookies(ctx, h.cfg, accessToken, refreshToken)
+	ctx.JSON(http.StatusOK, refreshResponse{Status: "ok"})
 }
 
 func (h *Handler) Logout(ctx *gin.Context) {
-	var req refreshRequest
-	if err := ctx.ShouldBindJSON(&req); err != nil {
-		writeBindError(ctx, err)
-		return
+	refreshTokenValue, ok := currentRefreshToken(ctx)
+	if ok {
+		if err := h.auth.Logout(ctx.Request.Context(), refreshTokenValue); err != nil {
+			writeError(ctx, err)
+			return
+		}
 	}
 
-	if err := h.auth.Logout(ctx.Request.Context(), req.RefreshToken); err != nil {
-		writeError(ctx, err)
-		return
-	}
-
+	clearAuthCookies(ctx, h.cfg)
 	ctx.JSON(http.StatusOK, gin.H{"status": "ok"})
 }
 

--- a/internal/http/handlers/handler_test.go
+++ b/internal/http/handlers/handler_test.go
@@ -1164,22 +1164,21 @@ func TestOptionalUserID(t *testing.T) {
 		}
 	})
 
-	t.Run("invalid bearer format", func(t *testing.T) {
+	t.Run("missing access token cookie", func(t *testing.T) {
 		ctx, _ := newJSONContext(t, http.MethodGet, "/api/challenges", nil)
-		ctx.Request.Header.Set("Authorization", "Bad token")
 		if got := env.handler.optionalUserID(ctx); got != 0 {
 			t.Fatalf("expected 0, got %d", got)
 		}
 	})
 
-	t.Run("valid access token", func(t *testing.T) {
+	t.Run("valid access token cookie", func(t *testing.T) {
 		token, err := auth.GenerateAccessToken(env.cfg.JWT, 777, models.UserRole)
 		if err != nil {
 			t.Fatalf("GenerateAccessToken: %v", err)
 		}
 
 		ctx, _ := newJSONContext(t, http.MethodGet, "/api/challenges", nil)
-		ctx.Request.Header.Set("Authorization", "Bearer "+token)
+		ctx.Request.AddCookie(&http.Cookie{Name: "access_token", Value: token})
 		if got := env.handler.optionalUserID(ctx); got != 777 {
 			t.Fatalf("expected 777, got %d", got)
 		}
@@ -1512,18 +1511,40 @@ func TestHandlerAuthMeUpdateFlow(t *testing.T) {
 			t.Fatalf("decode login: %v", err)
 		}
 
-		if loginResp.AccessToken == "" || loginResp.RefreshToken == "" {
-			t.Fatalf("expected tokens in login response: %+v", loginResp)
+		setCookies := rec.Header().Values("Set-Cookie")
+		if len(setCookies) == 0 {
+			t.Fatalf("expected auth cookies on login")
 		}
 
-		refreshBody := []byte(`{"refresh_token":"` + loginResp.RefreshToken + `"}`)
-		ctx, rec = newJSONContext(t, http.MethodPost, "/api/refresh", refreshBody)
+		refreshToken := ""
+		csrfToken := ""
+		for _, c := range setCookies {
+			if after, ok := strings.CutPrefix(c, "refresh_token="); ok {
+				refreshToken = strings.SplitN(after, ";", 2)[0]
+			}
+
+			if after, ok := strings.CutPrefix(c, "csrf_token="); ok {
+				csrfToken = strings.SplitN(after, ";", 2)[0]
+			}
+		}
+
+		if refreshToken == "" || csrfToken == "" {
+			t.Fatalf("expected refresh/csrf cookies on login")
+		}
+
+		ctx, rec = newJSONContext(t, http.MethodPost, "/api/refresh", nil)
+		ctx.Request.AddCookie(&http.Cookie{Name: "refresh_token", Value: refreshToken})
+		ctx.Request.AddCookie(&http.Cookie{Name: "csrf_token", Value: csrfToken})
+		ctx.Request.Header.Set("X-CSRF-Token", csrfToken)
 		env.handler.Refresh(ctx)
 		if rec.Code != http.StatusOK {
 			t.Fatalf("refresh status %d: %s", rec.Code, rec.Body.String())
 		}
 
-		ctx, rec = newJSONContext(t, http.MethodPost, "/api/logout", refreshBody)
+		ctx, rec = newJSONContext(t, http.MethodPost, "/api/logout", nil)
+		ctx.Request.AddCookie(&http.Cookie{Name: "refresh_token", Value: refreshToken})
+		ctx.Request.AddCookie(&http.Cookie{Name: "csrf_token", Value: csrfToken})
+		ctx.Request.Header.Set("X-CSRF-Token", csrfToken)
 		env.handler.Logout(ctx)
 		if rec.Code != http.StatusOK {
 			t.Fatalf("logout status %d: %s", rec.Code, rec.Body.String())
@@ -1678,7 +1699,7 @@ func TestHandlerWriteupHandlers(t *testing.T) {
 	t.Run("challenge writeups visibility", func(t *testing.T) {
 		ctx, rec := newJSONContext(t, http.MethodGet, "/api/challenges/"+toStringID(challenge.ID)+"/writeups?page=1&page_size=10", nil)
 		ctx.Params = append(ctx.Params, ginParam("id", toStringID(challenge.ID)))
-		ctx.Request.Header.Set("Authorization", "Bearer "+viewerAccess)
+		ctx.Request.AddCookie(&http.Cookie{Name: "access_token", Value: viewerAccess})
 		env.handler.ChallengeWriteups(ctx)
 		if rec.Code != http.StatusOK {
 			t.Fatalf("expected 200 list unsolved viewer, got %d body=%s", rec.Code, rec.Body.String())
@@ -1711,7 +1732,7 @@ func TestHandlerWriteupHandlers(t *testing.T) {
 
 		ctx, rec = newJSONContext(t, http.MethodGet, "/api/writeups/"+toStringID(writeupID), nil)
 		ctx.Params = append(ctx.Params, ginParam("id", toStringID(writeupID)))
-		ctx.Request.Header.Set("Authorization", "Bearer "+viewerAccess)
+		ctx.Request.AddCookie(&http.Cookie{Name: "access_token", Value: viewerAccess})
 		env.handler.GetWriteup(ctx)
 		if rec.Code != http.StatusOK {
 			t.Fatalf("expected 200 get unsolved viewer, got %d body=%s", rec.Code, rec.Body.String())
@@ -1730,7 +1751,7 @@ func TestHandlerWriteupHandlers(t *testing.T) {
 
 		ctx, rec = newJSONContext(t, http.MethodGet, "/api/writeups/"+toStringID(writeupID), nil)
 		ctx.Params = append(ctx.Params, ginParam("id", toStringID(writeupID)))
-		ctx.Request.Header.Set("Authorization", "Bearer "+viewerAccess)
+		ctx.Request.AddCookie(&http.Cookie{Name: "access_token", Value: viewerAccess})
 		env.handler.GetWriteup(ctx)
 		if rec.Code != http.StatusOK {
 			t.Fatalf("expected 200 get solved viewer, got %d body=%s", rec.Code, rec.Body.String())
@@ -1816,7 +1837,7 @@ func TestHandlerWriteupHandlers(t *testing.T) {
 
 		ctx, rec = newJSONContext(t, http.MethodGet, "/api/users/"+toStringID(writer.ID)+"/writeups?page=1&page_size=10", nil)
 		ctx.Params = append(ctx.Params, ginParam("id", toStringID(writer.ID)))
-		ctx.Request.Header.Set("Authorization", "Bearer "+viewerAccess)
+		ctx.Request.AddCookie(&http.Cookie{Name: "access_token", Value: viewerAccess})
 		env.handler.GetUserWriteups(ctx)
 		if rec.Code != http.StatusOK {
 			t.Fatalf("expected 200 user writeups, got %d body=%s", rec.Code, rec.Body.String())

--- a/internal/http/handlers/handler_test.go
+++ b/internal/http/handlers/handler_test.go
@@ -1091,7 +1091,7 @@ func TestHandlerListChallengesAndUsers(t *testing.T) {
 		}
 
 		ctx, rec := newJSONContext(t, http.MethodGet, "/api/challenges?page=1&page_size=10", nil)
-		ctx.Request.Header.Set("Authorization", "Bearer "+accessToken)
+		ctx.Request.AddCookie(&http.Cookie{Name: "access_token", Value: accessToken})
 		env.handler.ListChallenges(ctx)
 		if rec.Code != http.StatusOK {
 			t.Fatalf("status %d: %s", rec.Code, rec.Body.String())
@@ -1157,15 +1157,16 @@ func TestParseIDParamOrError(t *testing.T) {
 func TestOptionalUserID(t *testing.T) {
 	env := setupHandlerTest(t)
 
-	t.Run("no authorization header", func(t *testing.T) {
+	t.Run("no access token cookie", func(t *testing.T) {
 		ctx, _ := newJSONContext(t, http.MethodGet, "/api/challenges", nil)
 		if got := env.handler.optionalUserID(ctx); got != 0 {
 			t.Fatalf("expected 0, got %d", got)
 		}
 	})
 
-	t.Run("missing access token cookie", func(t *testing.T) {
+	t.Run("invalid access token cookie", func(t *testing.T) {
 		ctx, _ := newJSONContext(t, http.MethodGet, "/api/challenges", nil)
+		ctx.Request.AddCookie(&http.Cookie{Name: "access_token", Value: "not-a-jwt"})
 		if got := env.handler.optionalUserID(ctx); got != 0 {
 			t.Fatalf("expected 0, got %d", got)
 		}
@@ -1212,7 +1213,7 @@ func TestHandlerGetChallengeAndSolvers(t *testing.T) {
 
 	t.Run("get challenge locked response", func(t *testing.T) {
 		ctx, rec := newJSONContext(t, http.MethodGet, "/api/challenges/"+toStringID(locked.ID), nil)
-		ctx.Request.Header.Set("Authorization", "Bearer "+token)
+		ctx.Request.AddCookie(&http.Cookie{Name: "access_token", Value: token})
 		ctx.Params = append(ctx.Params, ginParam("id", toStringID(locked.ID)))
 		env.handler.GetChallenge(ctx)
 		if rec.Code != http.StatusOK {
@@ -1242,7 +1243,7 @@ func TestHandlerGetChallengeAndSolvers(t *testing.T) {
 		}
 
 		ctx, rec := newJSONContext(t, http.MethodGet, "/api/challenges/"+toStringID(prev.ID), nil)
-		ctx.Request.Header.Set("Authorization", "Bearer "+token)
+		ctx.Request.AddCookie(&http.Cookie{Name: "access_token", Value: token})
 		ctx.Params = append(ctx.Params, ginParam("id", toStringID(prev.ID)))
 		env.handler.GetChallenge(ctx)
 		if rec.Code != http.StatusOK {

--- a/internal/http/handlers/types.go
+++ b/internal/http/handlers/types.go
@@ -67,10 +67,6 @@ type loginRequest struct {
 	Password string `json:"password" binding:"required"`
 }
 
-type refreshRequest struct {
-	RefreshToken string `json:"refresh_token" binding:"required"`
-}
-
 type createChallengeRequest struct {
 	Title               string                    `json:"title" binding:"required"`
 	Description         string                    `json:"description" binding:"required"`
@@ -138,14 +134,13 @@ type registerResponse struct {
 type loginUserResponse = userMeResponse
 
 type loginResponse struct {
-	AccessToken  string            `json:"access_token"`
-	RefreshToken string            `json:"refresh_token"`
+	AccessToken  string            `json:"access_token,omitempty"`
+	RefreshToken string            `json:"refresh_token,omitempty"`
 	User         loginUserResponse `json:"user"`
 }
 
 type refreshResponse struct {
-	AccessToken  string `json:"access_token"`
-	RefreshToken string `json:"refresh_token"`
+	Status string `json:"status"`
 }
 
 type userMeResponse struct {

--- a/internal/http/handlers/types.go
+++ b/internal/http/handlers/types.go
@@ -134,9 +134,7 @@ type registerResponse struct {
 type loginUserResponse = userMeResponse
 
 type loginResponse struct {
-	AccessToken  string            `json:"access_token,omitempty"`
-	RefreshToken string            `json:"refresh_token,omitempty"`
-	User         loginUserResponse `json:"user"`
+	User loginUserResponse `json:"user"`
 }
 
 type refreshResponse struct {

--- a/internal/http/integration/auth_test.go
+++ b/internal/http/integration/auth_test.go
@@ -135,17 +135,12 @@ func TestRefreshAndLogout(t *testing.T) {
 		t.Fatalf("status %d: %s", rec.Code, rec.Body.String())
 	}
 
-	var refreshResp struct {
-		AccessToken  string `json:"access_token"`
-		RefreshToken string `json:"refresh_token"`
-	}
-	decodeJSON(t, rec, &refreshResp)
-
-	if refreshResp.AccessToken == "" || refreshResp.RefreshToken == "" {
-		t.Fatalf("tokens should not be empty")
+	refreshed := cookieValueFromSetCookie(rec, "refresh_token")
+	if refreshed == "" {
+		t.Fatalf("refresh cookie should be set")
 	}
 
-	if refreshResp.RefreshToken == refresh {
+	if refreshed == refresh {
 		t.Fatalf("refresh token should rotate")
 	}
 
@@ -154,12 +149,12 @@ func TestRefreshAndLogout(t *testing.T) {
 		t.Fatalf("status %d: %s", rec.Code, rec.Body.String())
 	}
 
-	rec = doRequest(t, env.router, http.MethodPost, "/api/auth/logout", map[string]string{"refresh_token": refreshResp.RefreshToken}, nil)
+	rec = doRequest(t, env.router, http.MethodPost, "/api/auth/logout", map[string]string{"refresh_token": refreshed}, nil)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status %d: %s", rec.Code, rec.Body.String())
 	}
 
-	rec = doRequest(t, env.router, http.MethodPost, "/api/auth/refresh", map[string]string{"refresh_token": refreshResp.RefreshToken}, nil)
+	rec = doRequest(t, env.router, http.MethodPost, "/api/auth/refresh", map[string]string{"refresh_token": refreshed}, nil)
 	if rec.Code != http.StatusUnauthorized {
 		t.Fatalf("status %d: %s", rec.Code, rec.Body.String())
 	}

--- a/internal/http/integration/auth_test.go
+++ b/internal/http/integration/auth_test.go
@@ -130,7 +130,7 @@ func TestRefreshAndLogout(t *testing.T) {
 	env := setupTest(t, testCfg)
 	_, refresh, _ := registerAndLogin(t, env, "user@example.com", "user1", "strong-password")
 
-	rec := doRequest(t, env.router, http.MethodPost, "/api/auth/refresh", map[string]string{"refresh_token": refresh}, nil)
+	rec := doRequest(t, env.router, http.MethodPost, "/api/auth/refresh", nil, refreshHeader(refresh))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status %d: %s", rec.Code, rec.Body.String())
 	}
@@ -144,17 +144,17 @@ func TestRefreshAndLogout(t *testing.T) {
 		t.Fatalf("refresh token should rotate")
 	}
 
-	rec = doRequest(t, env.router, http.MethodPost, "/api/auth/refresh", map[string]string{"refresh_token": refresh}, nil)
+	rec = doRequest(t, env.router, http.MethodPost, "/api/auth/refresh", nil, refreshHeader(refresh))
 	if rec.Code != http.StatusUnauthorized {
 		t.Fatalf("status %d: %s", rec.Code, rec.Body.String())
 	}
 
-	rec = doRequest(t, env.router, http.MethodPost, "/api/auth/logout", map[string]string{"refresh_token": refreshed}, nil)
+	rec = doRequest(t, env.router, http.MethodPost, "/api/auth/logout", nil, refreshHeader(refreshed))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status %d: %s", rec.Code, rec.Body.String())
 	}
 
-	rec = doRequest(t, env.router, http.MethodPost, "/api/auth/refresh", map[string]string{"refresh_token": refreshed}, nil)
+	rec = doRequest(t, env.router, http.MethodPost, "/api/auth/refresh", nil, refreshHeader(refreshed))
 	if rec.Code != http.StatusUnauthorized {
 		t.Fatalf("status %d: %s", rec.Code, rec.Body.String())
 	}

--- a/internal/http/integration/testenv_test.go
+++ b/internal/http/integration/testenv_test.go
@@ -330,15 +330,6 @@ func doRequest(t *testing.T, router *gin.Engine, method, path string, body any, 
 				}
 			}
 		}
-
-		if req.Header.Get("Cookie") == "" {
-			if payload, ok := body.(map[string]string); ok {
-				if refreshToken := payload["refresh_token"]; refreshToken != "" {
-					req.Header.Set("Cookie", "refresh_token="+refreshToken+"; csrf_token=test-csrf")
-					req.Header.Set("X-CSRF-Token", "test-csrf")
-				}
-			}
-		}
 	}
 
 	rec := httptest.NewRecorder()
@@ -357,6 +348,10 @@ func decodeJSON(t *testing.T, rec *httptest.ResponseRecorder, dest any) {
 
 func authHeader(token string) map[string]string {
 	return map[string]string{"Cookie": "access_token=" + token + "; csrf_token=test-csrf", "X-CSRF-Token": "test-csrf"}
+}
+
+func refreshHeader(token string) map[string]string {
+	return map[string]string{"Cookie": "refresh_token=" + token + "; csrf_token=test-csrf", "X-CSRF-Token": "test-csrf"}
 }
 
 func cookieValueFromSetCookie(rec *httptest.ResponseRecorder, name string) string {

--- a/internal/http/integration/testenv_test.go
+++ b/internal/http/integration/testenv_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -317,6 +318,29 @@ func doRequest(t *testing.T, router *gin.Engine, method, path string, body any, 
 		req.Header.Set(k, v)
 	}
 
+	if method == http.MethodPost || method == http.MethodPut || method == http.MethodPatch || method == http.MethodDelete {
+		if req.Header.Get("X-CSRF-Token") == "" {
+			if cookieHeader := req.Header.Get("Cookie"); strings.Contains(cookieHeader, "csrf_token=") {
+				for part := range strings.SplitSeq(cookieHeader, ";") {
+					trimmed := strings.TrimSpace(part)
+					if after, ok := strings.CutPrefix(trimmed, "csrf_token="); ok {
+						req.Header.Set("X-CSRF-Token", after)
+						break
+					}
+				}
+			}
+		}
+
+		if req.Header.Get("Cookie") == "" {
+			if payload, ok := body.(map[string]string); ok {
+				if refreshToken := payload["refresh_token"]; refreshToken != "" {
+					req.Header.Set("Cookie", "refresh_token="+refreshToken+"; csrf_token=test-csrf")
+					req.Header.Set("X-CSRF-Token", "test-csrf")
+				}
+			}
+		}
+	}
+
 	rec := httptest.NewRecorder()
 	router.ServeHTTP(rec, req)
 
@@ -332,7 +356,18 @@ func decodeJSON(t *testing.T, rec *httptest.ResponseRecorder, dest any) {
 }
 
 func authHeader(token string) map[string]string {
-	return map[string]string{"Authorization": "Bearer " + token}
+	return map[string]string{"Cookie": "access_token=" + token + "; csrf_token=test-csrf", "X-CSRF-Token": "test-csrf"}
+}
+
+func cookieValueFromSetCookie(rec *httptest.ResponseRecorder, name string) string {
+	prefix := name + "="
+	for _, c := range rec.Header().Values("Set-Cookie") {
+		if after, ok := strings.CutPrefix(c, prefix); ok {
+			return strings.SplitN(after, ";", 2)[0]
+		}
+	}
+
+	return ""
 }
 
 func registerAndLogin(t *testing.T, env testEnv, email, username, password string) (string, string, int64) {
@@ -365,9 +400,7 @@ func registerAndLogin(t *testing.T, env testEnv, email, username, password strin
 	}
 
 	var loginResp struct {
-		AccessToken  string `json:"access_token"`
-		RefreshToken string `json:"refresh_token"`
-		User         struct {
+		User struct {
 			ID         int64 `json:"id"`
 			StackCount int   `json:"stack_count"`
 			StackLimit int   `json:"stack_limit"`
@@ -383,7 +416,13 @@ func registerAndLogin(t *testing.T, env testEnv, email, username, password strin
 		t.Fatalf("expected stack_limit %d, got %d", env.cfg.Stack.MaxPer, loginResp.User.StackLimit)
 	}
 
-	return loginResp.AccessToken, loginResp.RefreshToken, loginResp.User.ID
+	accessToken := cookieValueFromSetCookie(rec, "access_token")
+	refreshToken := cookieValueFromSetCookie(rec, "refresh_token")
+	if accessToken == "" || refreshToken == "" {
+		t.Fatalf("missing auth cookies from login response")
+	}
+
+	return accessToken, refreshToken, loginResp.User.ID
 }
 
 func createUser(t *testing.T, env testEnv, email, username, password, role string) *models.User {
@@ -420,9 +459,7 @@ func loginUser(t *testing.T, router *gin.Engine, email, password string) (string
 	}
 
 	var resp struct {
-		AccessToken  string `json:"access_token"`
-		RefreshToken string `json:"refresh_token"`
-		User         struct {
+		User struct {
 			ID         int64 `json:"id"`
 			StackCount int   `json:"stack_count"`
 			StackLimit int   `json:"stack_limit"`
@@ -430,8 +467,13 @@ func loginUser(t *testing.T, router *gin.Engine, email, password string) (string
 	}
 
 	decodeJSON(t, rec, &resp)
+	accessToken := cookieValueFromSetCookie(rec, "access_token")
+	refreshToken := cookieValueFromSetCookie(rec, "refresh_token")
+	if accessToken == "" || refreshToken == "" {
+		t.Fatalf("missing auth cookies from login response")
+	}
 
-	return resp.AccessToken, resp.RefreshToken, resp.User.ID
+	return accessToken, refreshToken, resp.User.ID
 }
 
 func ensureAdminUser(t *testing.T, env testEnv) *models.User {

--- a/internal/http/middleware/auth.go
+++ b/internal/http/middleware/auth.go
@@ -3,7 +3,6 @@ package middleware
 import (
 	"context"
 	"net/http"
-	"strings"
 
 	"wargame/internal/auth"
 	"wargame/internal/config"
@@ -18,26 +17,19 @@ const (
 	ctxRoleKey   = "role"
 
 	errMissingAuth  = "missing authorization"
-	errInvalidAuth  = "invalid authorization"
 	errInvalidToken = "invalid token"
 	errForbidden    = "forbidden"
 )
 
 func Auth(cfg config.JWTConfig) gin.HandlerFunc {
 	return func(ctx *gin.Context) {
-		authHeader := ctx.GetHeader("Authorization")
-		if authHeader == "" {
+		token, err := ctx.Cookie("access_token")
+		if err != nil || token == "" {
 			ctx.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": errMissingAuth})
 			return
 		}
 
-		parts := strings.SplitN(authHeader, " ", 2)
-		if len(parts) != 2 || !strings.EqualFold(parts[0], "Bearer") {
-			ctx.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": errInvalidAuth})
-			return
-		}
-
-		claims, err := auth.ParseToken(cfg, parts[1])
+		claims, err := auth.ParseToken(cfg, token)
 		if err != nil {
 			ctx.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": errInvalidToken})
 			return

--- a/internal/http/middleware/auth.go
+++ b/internal/http/middleware/auth.go
@@ -16,7 +16,7 @@ const (
 	ctxUserIDKey = "userID"
 	ctxRoleKey   = "role"
 
-	errMissingAuth  = "missing authorization"
+	errMissingAuth  = "missing access_token cookie"
 	errInvalidToken = "invalid token"
 	errForbidden    = "forbidden"
 )

--- a/internal/http/middleware/auth_test.go
+++ b/internal/http/middleware/auth_test.go
@@ -50,16 +50,7 @@ func TestAuthMiddleware(t *testing.T) {
 
 	rec = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodGet, "/protected", nil)
-	req.Header.Set("Authorization", "Token abc")
-
-	router.ServeHTTP(rec, req)
-	if rec.Code != http.StatusUnauthorized {
-		t.Fatalf("expected 401, got %d", rec.Code)
-	}
-
-	rec = httptest.NewRecorder()
-	req = httptest.NewRequest(http.MethodGet, "/protected", nil)
-	req.Header.Set("Authorization", "Bearer invalid.token")
+	req.AddCookie(&http.Cookie{Name: "access_token", Value: "invalid.token"})
 
 	router.ServeHTTP(rec, req)
 	if rec.Code != http.StatusUnauthorized {
@@ -73,7 +64,7 @@ func TestAuthMiddleware(t *testing.T) {
 
 	rec = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodGet, "/protected", nil)
-	req.Header.Set("Authorization", "Bearer "+refresh)
+	req.AddCookie(&http.Cookie{Name: "access_token", Value: refresh})
 	router.ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusUnauthorized {
@@ -87,7 +78,7 @@ func TestAuthMiddleware(t *testing.T) {
 
 	rec = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodGet, "/protected", nil)
-	req.Header.Set("Authorization", "Bearer "+access)
+	req.AddCookie(&http.Cookie{Name: "access_token", Value: access})
 
 	router.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
@@ -116,7 +107,7 @@ func TestRequireRole(t *testing.T) {
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/admin", nil)
-	req.Header.Set("Authorization", "Bearer "+userToken)
+	req.AddCookie(&http.Cookie{Name: "access_token", Value: userToken})
 
 	router.ServeHTTP(rec, req)
 	if rec.Code != http.StatusForbidden {
@@ -130,7 +121,7 @@ func TestRequireRole(t *testing.T) {
 
 	rec = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodGet, "/admin", nil)
-	req.Header.Set("Authorization", "Bearer "+adminToken)
+	req.AddCookie(&http.Cookie{Name: "access_token", Value: adminToken})
 
 	router.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
@@ -176,7 +167,7 @@ func TestRequireActiveUser(t *testing.T) {
 
 	rec = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodGet, "/active", nil)
-	req.Header.Set("Authorization", "Bearer "+accessUser)
+	req.AddCookie(&http.Cookie{Name: "access_token", Value: accessUser})
 	router.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", rec.Code)
@@ -189,7 +180,7 @@ func TestRequireActiveUser(t *testing.T) {
 
 	rec = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodGet, "/active", nil)
-	req.Header.Set("Authorization", "Bearer "+accessBlocked)
+	req.AddCookie(&http.Cookie{Name: "access_token", Value: accessBlocked})
 	router.ServeHTTP(rec, req)
 	if rec.Code != http.StatusForbidden {
 		t.Fatalf("expected 403, got %d", rec.Code)
@@ -198,7 +189,7 @@ func TestRequireActiveUser(t *testing.T) {
 	users.err = errors.New("db down")
 	rec = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodGet, "/active", nil)
-	req.Header.Set("Authorization", "Bearer "+accessUser)
+	req.AddCookie(&http.Cookie{Name: "access_token", Value: accessUser})
 	router.ServeHTTP(rec, req)
 	if rec.Code != http.StatusUnauthorized {
 		t.Fatalf("expected 401, got %d", rec.Code)

--- a/internal/http/middleware/cors.go
+++ b/internal/http/middleware/cors.go
@@ -16,7 +16,10 @@ func CORS(allowAll bool, allowedOrigins []string) gin.HandlerFunc {
 	return func(ctx *gin.Context) {
 		origin := ctx.GetHeader("Origin")
 		if allowAll {
-			ctx.Writer.Header().Set("Access-Control-Allow-Origin", "*")
+			if origin != "" {
+				ctx.Writer.Header().Set("Access-Control-Allow-Origin", origin)
+				ctx.Writer.Header().Set("Vary", "Origin")
+			}
 		} else if origin != "" {
 			if _, ok := allowed[origin]; ok {
 				ctx.Writer.Header().Set("Access-Control-Allow-Origin", origin)
@@ -26,11 +29,7 @@ func CORS(allowAll bool, allowedOrigins []string) gin.HandlerFunc {
 
 		ctx.Writer.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
 		ctx.Writer.Header().Set("Access-Control-Allow-Headers", "Content-Type, Cache-Control, Pragma, X-CSRF-Token")
-		if allowAll {
-			ctx.Writer.Header().Set("Access-Control-Allow-Credentials", "false")
-		} else {
-			ctx.Writer.Header().Set("Access-Control-Allow-Credentials", "true")
-		}
+		ctx.Writer.Header().Set("Access-Control-Allow-Credentials", "true")
 
 		if ctx.Request.Method == http.MethodOptions {
 			ctx.AbortWithStatus(http.StatusNoContent)

--- a/internal/http/middleware/cors.go
+++ b/internal/http/middleware/cors.go
@@ -16,7 +16,10 @@ func CORS(allowAll bool, allowedOrigins []string) gin.HandlerFunc {
 	return func(ctx *gin.Context) {
 		origin := ctx.GetHeader("Origin")
 		if allowAll {
-			ctx.Writer.Header().Set("Access-Control-Allow-Origin", "*")
+			if origin != "" {
+				ctx.Writer.Header().Set("Access-Control-Allow-Origin", origin)
+				ctx.Writer.Header().Set("Vary", "Origin")
+			}
 		} else if origin != "" {
 			if _, ok := allowed[origin]; ok {
 				ctx.Writer.Header().Set("Access-Control-Allow-Origin", origin)
@@ -25,7 +28,7 @@ func CORS(allowAll bool, allowedOrigins []string) gin.HandlerFunc {
 		}
 
 		ctx.Writer.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
-		ctx.Writer.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type, Cache-Control, Pragma")
+		ctx.Writer.Header().Set("Access-Control-Allow-Headers", "Content-Type, Cache-Control, Pragma, X-CSRF-Token")
 		ctx.Writer.Header().Set("Access-Control-Allow-Credentials", "true")
 
 		if ctx.Request.Method == http.MethodOptions {

--- a/internal/http/middleware/cors.go
+++ b/internal/http/middleware/cors.go
@@ -29,6 +29,7 @@ func CORS(allowAll bool, allowedOrigins []string) gin.HandlerFunc {
 
 		ctx.Writer.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
 		ctx.Writer.Header().Set("Access-Control-Allow-Headers", "Content-Type, Cache-Control, Pragma, X-CSRF-Token")
+		ctx.Writer.Header().Set("Access-Control-Expose-Headers", "X-CSRF-Token")
 		ctx.Writer.Header().Set("Access-Control-Allow-Credentials", "true")
 
 		if ctx.Request.Method == http.MethodOptions {

--- a/internal/http/middleware/cors.go
+++ b/internal/http/middleware/cors.go
@@ -16,10 +16,7 @@ func CORS(allowAll bool, allowedOrigins []string) gin.HandlerFunc {
 	return func(ctx *gin.Context) {
 		origin := ctx.GetHeader("Origin")
 		if allowAll {
-			if origin != "" {
-				ctx.Writer.Header().Set("Access-Control-Allow-Origin", origin)
-				ctx.Writer.Header().Set("Vary", "Origin")
-			}
+			ctx.Writer.Header().Set("Access-Control-Allow-Origin", "*")
 		} else if origin != "" {
 			if _, ok := allowed[origin]; ok {
 				ctx.Writer.Header().Set("Access-Control-Allow-Origin", origin)
@@ -29,7 +26,11 @@ func CORS(allowAll bool, allowedOrigins []string) gin.HandlerFunc {
 
 		ctx.Writer.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
 		ctx.Writer.Header().Set("Access-Control-Allow-Headers", "Content-Type, Cache-Control, Pragma, X-CSRF-Token")
-		ctx.Writer.Header().Set("Access-Control-Allow-Credentials", "true")
+		if allowAll {
+			ctx.Writer.Header().Set("Access-Control-Allow-Credentials", "false")
+		} else {
+			ctx.Writer.Header().Set("Access-Control-Allow-Credentials", "true")
+		}
 
 		if ctx.Request.Method == http.MethodOptions {
 			ctx.AbortWithStatus(http.StatusNoContent)

--- a/internal/http/middleware/cors_test.go
+++ b/internal/http/middleware/cors_test.go
@@ -26,8 +26,8 @@ func TestCORSAllowAll(t *testing.T) {
 		t.Fatalf("expected 200, got %d", rec.Code)
 	}
 
-	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "*" {
-		t.Fatalf("expected '*', got %q", got)
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "https://evil.example.com" {
+		t.Fatalf("expected origin echo, got %q", got)
 	}
 
 	if got := rec.Header().Get("Access-Control-Allow-Methods"); got == "" {
@@ -38,8 +38,12 @@ func TestCORSAllowAll(t *testing.T) {
 		t.Fatalf("expected Allow-Headers header")
 	}
 
-	if got := rec.Header().Get("Access-Control-Allow-Credentials"); got != "false" {
-		t.Fatalf("expected credentials false, got %q", got)
+	if got := rec.Header().Get("Access-Control-Allow-Credentials"); got != "true" {
+		t.Fatalf("expected credentials true, got %q", got)
+	}
+
+	if got := rec.Header().Get("Vary"); got != "Origin" {
+		t.Fatalf("expected Vary=Origin, got %q", got)
 	}
 }
 
@@ -121,7 +125,7 @@ func TestCORSPreflight(t *testing.T) {
 		t.Fatalf("expected 204, got %d", rec.Code)
 	}
 
-	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "*" {
-		t.Fatalf("expected '*', got %q", got)
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "https://example.com" {
+		t.Fatalf("expected origin echo, got %q", got)
 	}
 }

--- a/internal/http/middleware/cors_test.go
+++ b/internal/http/middleware/cors_test.go
@@ -26,8 +26,8 @@ func TestCORSAllowAll(t *testing.T) {
 		t.Fatalf("expected 200, got %d", rec.Code)
 	}
 
-	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "*" {
-		t.Fatalf("expected '*', got %q", got)
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "https://evil.example.com" {
+		t.Fatalf("expected origin echo, got %q", got)
 	}
 
 	if got := rec.Header().Get("Access-Control-Allow-Methods"); got == "" {
@@ -117,7 +117,7 @@ func TestCORSPreflight(t *testing.T) {
 		t.Fatalf("expected 204, got %d", rec.Code)
 	}
 
-	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "*" {
-		t.Fatalf("expected '*', got %q", got)
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "https://example.com" {
+		t.Fatalf("expected origin echo, got %q", got)
 	}
 }

--- a/internal/http/middleware/cors_test.go
+++ b/internal/http/middleware/cors_test.go
@@ -26,8 +26,8 @@ func TestCORSAllowAll(t *testing.T) {
 		t.Fatalf("expected 200, got %d", rec.Code)
 	}
 
-	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "https://evil.example.com" {
-		t.Fatalf("expected origin echo, got %q", got)
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "*" {
+		t.Fatalf("expected '*', got %q", got)
 	}
 
 	if got := rec.Header().Get("Access-Control-Allow-Methods"); got == "" {
@@ -38,8 +38,8 @@ func TestCORSAllowAll(t *testing.T) {
 		t.Fatalf("expected Allow-Headers header")
 	}
 
-	if got := rec.Header().Get("Access-Control-Allow-Credentials"); got != "true" {
-		t.Fatalf("expected credentials true, got %q", got)
+	if got := rec.Header().Get("Access-Control-Allow-Credentials"); got != "false" {
+		t.Fatalf("expected credentials false, got %q", got)
 	}
 }
 
@@ -70,6 +70,10 @@ func TestCORSAllowedOrigin(t *testing.T) {
 
 	if got := rec.Header().Get("Vary"); got != "Origin" {
 		t.Fatalf("expected Vary=Origin, got %q", got)
+	}
+
+	if got := rec.Header().Get("Access-Control-Allow-Credentials"); got != "true" {
+		t.Fatalf("expected credentials true, got %q", got)
 	}
 }
 
@@ -117,7 +121,7 @@ func TestCORSPreflight(t *testing.T) {
 		t.Fatalf("expected 204, got %d", rec.Code)
 	}
 
-	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "https://example.com" {
-		t.Fatalf("expected origin echo, got %q", got)
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "*" {
+		t.Fatalf("expected '*', got %q", got)
 	}
 }

--- a/internal/http/middleware/csrf.go
+++ b/internal/http/middleware/csrf.go
@@ -57,5 +57,8 @@ func requiresCSRF(method string) bool {
 }
 
 func isCSRFIgnoredPath(path string) bool {
-	return path == "/api/auth/login" || path == "/api/auth/register"
+	return path == "/api/auth/login" ||
+		path == "/api/auth/register" ||
+		path == "/api/auth/refresh" ||
+		path == "/api/auth/logout"
 }

--- a/internal/http/middleware/csrf.go
+++ b/internal/http/middleware/csrf.go
@@ -1,0 +1,61 @@
+package middleware
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	csrfCookieName = "csrf_token"
+	csrfHeaderName = "X-CSRF-Token"
+)
+
+func CSRF() gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+		if !requiresCSRF(ctx.Request.Method) {
+			ctx.Next()
+			return
+		}
+
+		if isCSRFIgnoredPath(ctx.Request.URL.Path) {
+			ctx.Next()
+			return
+		}
+
+		_, accessErr := ctx.Cookie("access_token")
+		_, refreshErr := ctx.Cookie("refresh_token")
+		if accessErr != nil && refreshErr != nil {
+			ctx.Next()
+			return
+		}
+
+		cookieToken, err := ctx.Cookie(csrfCookieName)
+		if err != nil || cookieToken == "" {
+			ctx.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+			return
+		}
+
+		headerToken := strings.TrimSpace(ctx.GetHeader(csrfHeaderName))
+		if headerToken == "" || headerToken != cookieToken {
+			ctx.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+			return
+		}
+
+		ctx.Next()
+	}
+}
+
+func requiresCSRF(method string) bool {
+	switch method {
+	case http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete:
+		return true
+	default:
+		return false
+	}
+}
+
+func isCSRFIgnoredPath(path string) bool {
+	return path == "/api/auth/login" || path == "/api/auth/register"
+}

--- a/internal/http/middleware/csrf_test.go
+++ b/internal/http/middleware/csrf_test.go
@@ -1,0 +1,181 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func setupCSRFRouter(handler gin.HandlerFunc) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(CSRF())
+	r.POST("/test", handler)
+	r.GET("/test", handler)
+	r.POST("/api/auth/login", handler)
+
+	return r
+}
+
+func TestRequiresCSRF(t *testing.T) {
+	if !requiresCSRF(http.MethodPost) || !requiresCSRF(http.MethodPut) || !requiresCSRF(http.MethodPatch) || !requiresCSRF(http.MethodDelete) {
+		t.Fatal("expected modifying methods to require csrf")
+	}
+
+	if requiresCSRF(http.MethodGet) || requiresCSRF(http.MethodHead) || requiresCSRF(http.MethodOptions) {
+		t.Fatal("expected safe methods to skip csrf")
+	}
+}
+
+func TestCSRFIgnoredPath(t *testing.T) {
+	if !isCSRFIgnoredPath("/api/auth/login") {
+		t.Fatal("expected login path ignored")
+	}
+
+	if !isCSRFIgnoredPath("/api/auth/register") {
+		t.Fatal("expected register path ignored")
+	}
+
+	if isCSRFIgnoredPath("/api/challenges/1/submit") {
+		t.Fatal("expected non-auth path not ignored")
+	}
+}
+
+func TestCSRFMiddleware_SafeMethodPasses(t *testing.T) {
+	called := false
+	r := setupCSRFRouter(func(ctx *gin.Context) {
+		called = true
+		ctx.Status(http.StatusOK)
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK || !called {
+		t.Fatalf("expected pass-through for safe method, status=%d called=%v", rec.Code, called)
+	}
+}
+
+func TestCSRFMiddleware_IgnoredAuthPathPasses(t *testing.T) {
+	called := false
+	r := setupCSRFRouter(func(ctx *gin.Context) {
+		called = true
+		ctx.Status(http.StatusOK)
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/login", nil)
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK || !called {
+		t.Fatalf("expected pass-through for ignored path, status=%d called=%v", rec.Code, called)
+	}
+}
+
+func TestCSRFMiddleware_NoAuthCookiesPasses(t *testing.T) {
+	called := false
+	r := setupCSRFRouter(func(ctx *gin.Context) {
+		called = true
+		ctx.Status(http.StatusOK)
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/test", nil)
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK || !called {
+		t.Fatalf("expected pass-through without auth cookies, status=%d called=%v", rec.Code, called)
+	}
+}
+
+func TestCSRFMiddleware_WithAuthCookieMissingCSRFCookieForbidden(t *testing.T) {
+	called := false
+	r := setupCSRFRouter(func(ctx *gin.Context) {
+		called = true
+		ctx.Status(http.StatusOK)
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/test", nil)
+	req.AddCookie(&http.Cookie{Name: "access_token", Value: "token"})
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", rec.Code)
+	}
+
+	if called {
+		t.Fatal("handler should not be called")
+	}
+}
+
+func TestCSRFMiddleware_WithAuthCookieMissingHeaderForbidden(t *testing.T) {
+	called := false
+	r := setupCSRFRouter(func(ctx *gin.Context) {
+		called = true
+		ctx.Status(http.StatusOK)
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/test", nil)
+	req.AddCookie(&http.Cookie{Name: "refresh_token", Value: "token"})
+	req.AddCookie(&http.Cookie{Name: csrfCookieName, Value: "csrf-1"})
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", rec.Code)
+	}
+
+	if called {
+		t.Fatal("handler should not be called")
+	}
+}
+
+func TestCSRFMiddleware_WithAuthCookieMismatchForbidden(t *testing.T) {
+	called := false
+	r := setupCSRFRouter(func(ctx *gin.Context) {
+		called = true
+		ctx.Status(http.StatusOK)
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/test", nil)
+	req.AddCookie(&http.Cookie{Name: "access_token", Value: "token"})
+	req.AddCookie(&http.Cookie{Name: csrfCookieName, Value: "csrf-1"})
+	req.Header.Set(csrfHeaderName, "csrf-2")
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", rec.Code)
+	}
+
+	if called {
+		t.Fatal("handler should not be called")
+	}
+}
+
+func TestCSRFMiddleware_WithAuthCookieAndMatchPasses(t *testing.T) {
+	called := false
+	r := setupCSRFRouter(func(ctx *gin.Context) {
+		called = true
+		ctx.Status(http.StatusOK)
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/test", nil)
+	req.AddCookie(&http.Cookie{Name: "access_token", Value: "token"})
+	req.AddCookie(&http.Cookie{Name: csrfCookieName, Value: "csrf-ok"})
+	req.Header.Set(csrfHeaderName, " csrf-ok ")
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	if !called {
+		t.Fatal("handler should be called")
+	}
+}

--- a/internal/http/middleware/csrf_test.go
+++ b/internal/http/middleware/csrf_test.go
@@ -15,6 +15,8 @@ func setupCSRFRouter(handler gin.HandlerFunc) *gin.Engine {
 	r.POST("/test", handler)
 	r.GET("/test", handler)
 	r.POST("/api/auth/login", handler)
+	r.POST("/api/auth/refresh", handler)
+	r.POST("/api/auth/logout", handler)
 
 	return r
 }
@@ -36,6 +38,14 @@ func TestCSRFIgnoredPath(t *testing.T) {
 
 	if !isCSRFIgnoredPath("/api/auth/register") {
 		t.Fatal("expected register path ignored")
+	}
+
+	if !isCSRFIgnoredPath("/api/auth/refresh") {
+		t.Fatal("expected refresh path ignored")
+	}
+
+	if !isCSRFIgnoredPath("/api/auth/logout") {
+		t.Fatal("expected logout path ignored")
 	}
 
 	if isCSRFIgnoredPath("/api/challenges/1/submit") {

--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -24,6 +24,7 @@ func NewRouter(cfg config.Config, authSvc *service.AuthService, wargameSvc *serv
 	r.Use(middleware.RecoveryLogger(logger))
 	r.Use(middleware.RequestLogger(cfg.Logging, logger))
 	r.Use(middleware.CORS(cfg.AppEnv != "production", cfg.CORS.AllowedOrigins))
+	r.Use(middleware.CSRF())
 
 	h := handlers.New(cfg, authSvc, wargameSvc, userSvc, affiliationSvc, scoreSvc, stackSvc, redis)
 

--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -23,7 +23,7 @@ func NewRouter(cfg config.Config, authSvc *service.AuthService, wargameSvc *serv
 	r := gin.New()
 	r.Use(middleware.RecoveryLogger(logger))
 	r.Use(middleware.RequestLogger(cfg.Logging, logger))
-	r.Use(middleware.CORS(false, cfg.CORS.AllowedOrigins))
+	r.Use(middleware.CORS(cfg.AppEnv == "local", cfg.CORS.AllowedOrigins))
 	r.Use(middleware.CSRF())
 
 	h := handlers.New(cfg, authSvc, wargameSvc, userSvc, affiliationSvc, scoreSvc, stackSvc, redis)

--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -23,7 +23,7 @@ func NewRouter(cfg config.Config, authSvc *service.AuthService, wargameSvc *serv
 	r := gin.New()
 	r.Use(middleware.RecoveryLogger(logger))
 	r.Use(middleware.RequestLogger(cfg.Logging, logger))
-	r.Use(middleware.CORS(cfg.AppEnv != "production", cfg.CORS.AllowedOrigins))
+	r.Use(middleware.CORS(false, cfg.CORS.AllowedOrigins))
 	r.Use(middleware.CSRF())
 
 	h := handlers.New(cfg, authSvc, wargameSvc, userSvc, affiliationSvc, scoreSvc, stackSvc, redis)


### PR DESCRIPTION
Previously, authentication relied on basic JWT access and refresh tokens, which were stored in the frontend’s local storage. To further strengthen security beyond this basic setup, the following measures have been introduced:

- Change in token delivery method - Instead of sending tokens in the request body, both tokens are now delivered via HttpOnly cookies.
- CSRF protection - A CSRF token is issued during login and refresh, and protected using the Double Submit pattern.

Additionally, minor CORS-related logic has been adjusted, and several frontend bugs have been fixed. Other security measures such as CSP, nosniff, Referrer-Policy, and HSTS may be considered later, but for now, only the most fundamental protections have been implemented.

The previous method of passing authentication tokens via the request body is no longer supported, and no migration or fallback has been intentionally provided.

For more details, please refer to the changes.
