### PR TITLE
Allow Challenge Authors to Create and View Writeups Without Solving the Challenge

### DIFF
--- a/docs/docs/writeups.md
+++ b/docs/docs/writeups.md
@@ -58,6 +58,7 @@ Response 200
 Notes:
 
 - `content` is included only when `can_view_content` is `true`.
+- `can_view_content` is `true` when the viewer solved the challenge or is the challenge creator.
 - Metadata fields are always returned.
 
 Errors:
@@ -104,6 +105,7 @@ Response 200
 Notes:
 
 - `content` may be omitted when `can_view_content` is `false`.
+- `can_view_content` is `true` when the viewer solved the challenge or is the challenge creator.
 
 Errors:
 
@@ -160,7 +162,8 @@ Response 201
 Rules:
 
 - One writeup per `(user, challenge)`.
-- Only users who solved the challenge can create.
+- Users who solved the challenge can create.
+- The challenge creator can create a writeup for that challenge without solving it.
 
 Errors:
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -162,6 +162,18 @@ const App = () => {
         return <RouteComponent routeParams={routeParams} />
     }, [RouteComponent, booting, routeParams, t])
 
+    if (false) {
+        return (
+            <div className='flex min-h-screen items-center justify-center bg-slate-950 px-4'>
+                <div className='w-full max-w-md rounded-2xl border border-slate-700 bg-slate-900 px-8 py-10 text-center shadow-2xl'>
+                    <h1 className='text-2xl font-bold text-white'>서버 운영 시간이 아닙니다.</h1>
+
+                    <p className='mt-4 text-sm text-slate-400'>주인장 서버 컴퓨터도 밤엔 자야합니다. 아침 시간대에 다시 방문해주세요.</p>
+                </div>
+            </div>
+        )
+    }
+
     return (
         <>
             <div className='min-h-screen bg-background flex flex-col overflow-x-hidden'>

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -460,6 +460,7 @@
     "writeup.deleting": "Deleting...",
     "writeup.hiddenUntilSolved": "Solve this challenge to view writeup contents.",
     "writeup.hint": "You can write a writeup after solving the challenge. Share your approach and solution to help others learn!",
+    "writeup.authorHint": "Challenge creators can write a writeup without solving and can view every writeup for their challenge.",
     "writeup.metaOnlyHint": "You can write a writeup, but its contents will be hidden until you solve the challenge.",
     "writeup.alreadyExists": "You already published a writeup for this challenge.",
     "writeup.empty": "No writeups yet.",

--- a/frontend/src/locales/ja.json
+++ b/frontend/src/locales/ja.json
@@ -460,6 +460,7 @@
     "writeup.deleting": "削除中...",
     "writeup.hiddenUntilSolved": "この問題を解くとWriteup本文を閲覧できます。作成者と時刻情報は表示されます。",
     "writeup.hint": "この問題を解いた後、Writeupを作成してみましょう。あなたのアプローチや解法を共有して、他の人の学習を助けましょう!",
+    "writeup.authorHint": "作問者は解答済みでなくてもこの問題のWriteupを作成でき、すべてのWriteupを閲覧できます。",
     "writeup.metaOnlyHint": "一覧では作成者と時刻のみ表示します。本文は権限がある場合に詳細ページで確認できます。",
     "writeup.alreadyExists": "この問題にはすでに自分のWriteupがあります。",
     "writeup.empty": "まだWriteupがありません。",

--- a/frontend/src/locales/ko.json
+++ b/frontend/src/locales/ko.json
@@ -448,6 +448,7 @@
     "writeup.deleting": "삭제 중...",
     "writeup.hiddenUntilSolved": "이 문제를 해결해야 Writeup 본문을 볼 수 있습니다. 작성자와 시각 정보는 표시됩니다.",
     "writeup.hint": "문제를 해결한 후 Writeup을 작성할 수 있습니다. 풀이 과정과 해결 방법을 공유해보세요!",
+    "writeup.authorHint": "출제자는 풀이 없이도 이 문제의 Writeup을 작성하고 모든 Writeup을 볼 수 있습니다.",
     "writeup.metaOnlyHint": "Writeup 목록에서는 작성자와 시각 정보만 표시됩니다. 본문은 상세 페이지에서 권한에 따라 확인할 수 있습니다.",
     "writeup.alreadyExists": "이 문제에는 이미 내 Writeup이 있습니다.",
     "writeup.empty": "아직 작성된 Writeup이 없습니다.",

--- a/frontend/src/routes/ChallengeDetail.tsx
+++ b/frontend/src/routes/ChallengeDetail.tsx
@@ -919,7 +919,9 @@ const ChallengeDetail = ({ routeParams = {} }: RouteProps) => {
                         {!challenge.is_locked ? (
                             <WriteupsSection
                                 challengeId={challengeId}
-                                challengeSolved={challenge.is_solved || isChallengeAuthor}
+                                challengeSolved={challenge.is_solved}
+                                canCreateWriteup={challenge.is_solved || isChallengeAuthor}
+                                isChallengeAuthor={isChallengeAuthor}
                                 hasMyWriteup={hasMyWriteup}
                                 writeups={writeups}
                                 writeupLoading={writeupLoading}

--- a/frontend/src/routes/ChallengeDetail.tsx
+++ b/frontend/src/routes/ChallengeDetail.tsx
@@ -525,6 +525,7 @@ const ChallengeDetail = ({ routeParams = {} }: RouteProps) => {
     const firstBloodSolvedAfterLabel = firstBloodDuration ? renderFirstBloodDuration({ count: firstBloodDuration.count }) : null
     const currentLevel = normalizeLevel(challenge?.level)
     const levelLabel = currentLevel > 0 ? String(currentLevel) : t('level.unknown')
+    const isChallengeAuthor = Boolean(challenge?.created_by?.user_id && auth.user?.id && challenge.created_by.user_id === auth.user.id)
     const voteCountsByLevel = useMemo(() => {
         const source = challenge && 'level_vote_counts' in challenge ? (challenge.level_vote_counts ?? []) : []
         const mapped = new Map<number, number>()
@@ -918,7 +919,7 @@ const ChallengeDetail = ({ routeParams = {} }: RouteProps) => {
                         {!challenge.is_locked ? (
                             <WriteupsSection
                                 challengeId={challengeId}
-                                challengeSolved={challenge.is_solved}
+                                challengeSolved={challenge.is_solved || isChallengeAuthor}
                                 hasMyWriteup={hasMyWriteup}
                                 writeups={writeups}
                                 writeupLoading={writeupLoading}

--- a/frontend/src/routes/WriteupEditor.tsx
+++ b/frontend/src/routes/WriteupEditor.tsx
@@ -148,6 +148,7 @@ const WriteupEditor = ({ routeParams = {} }: RouteProps) => {
     const authorName = auth.user?.username?.trim() || t('common.na')
     const authorAffiliation = auth.user?.affiliation?.trim()
     const authorBio = auth.user?.bio?.trim()
+    const canWriteWriteup = Boolean(auth.user && (summaryChallenge.is_solved || summaryChallenge.created_by?.user_id === auth.user.id))
 
     return (
         <section className='animate space-y-4 px-0 sm:px-1 md:px-2 lg:px-0'>
@@ -186,9 +187,9 @@ const WriteupEditor = ({ routeParams = {} }: RouteProps) => {
                     </div>
 
                     {!auth.user ? <div className='rounded-xl bg-warning/10 p-4 text-sm text-warning'>{t('writeup.loginRequired')}</div> : null}
-                    {auth.user && !summaryChallenge.is_solved ? <div className='rounded-xl bg-warning/10 p-4 text-sm text-warning'>{t('writeup.hiddenUntilSolved')}</div> : null}
+                    {auth.user && !canWriteWriteup ? <div className='rounded-xl bg-warning/10 p-4 text-sm text-warning'>{t('writeup.hiddenUntilSolved')}</div> : null}
 
-                    {auth.user && summaryChallenge.is_solved ? (
+                    {canWriteWriteup ? (
                         <div className='min-w-0 border-t border-border/70 pt-8 sm:pt-10'>
                             <div className='rounded-2xl bg-surface/70 p-4 sm:p-5'>
                                 <MonacoEditor value={content} onChange={setContent} language='markdown' height='420px' />

--- a/frontend/src/routes/challenge-detail/WriteupsSection.tsx
+++ b/frontend/src/routes/challenge-detail/WriteupsSection.tsx
@@ -6,6 +6,8 @@ import type { PaginationMeta, Writeup } from '../../lib/types'
 interface WriteupsSectionProps {
     challengeId: number
     challengeSolved: boolean
+    canCreateWriteup: boolean
+    isChallengeAuthor: boolean
     hasMyWriteup: boolean
     writeups: Writeup[]
     writeupLoading: boolean
@@ -24,6 +26,8 @@ const WRITEUP_NOTICE_DISMISSED_KEY = 'writeup_notice_dismissed'
 const WriteupsSection = ({
     challengeId,
     challengeSolved,
+    canCreateWriteup,
+    isChallengeAuthor,
     hasMyWriteup,
     writeups,
     writeupLoading,
@@ -42,7 +46,7 @@ const WriteupsSection = ({
                 <h3 className='text-lg font-semibold text-text'>
                     {t('writeup.sectionTitle')} <span className='text-accent'>{writeupPagination.total_count}</span>
                 </h3>
-                {challengeSolved && !hasMyWriteup ? (
+                {canCreateWriteup && !hasMyWriteup ? (
                     <button
                         className='rounded-md border border-accent/40 px-3 py-1.5 text-xs font-medium text-accent hover:bg-accent/10'
                         onClick={() => {
@@ -55,7 +59,7 @@ const WriteupsSection = ({
             </div>
 
             <DismissibleNotice className='mt-3 rounded-lg' closeAriaLabel={t('common.close')} storageKey={WRITEUP_NOTICE_DISMISSED_KEY} size='small'>
-                {t('writeup.hint')}
+                {isChallengeAuthor && !challengeSolved ? t('writeup.authorHint') : t('writeup.hint')}
             </DismissibleNotice>
 
             <div className='mt-4 space-y-2'>

--- a/internal/http/integration/writeups_test.go
+++ b/internal/http/integration/writeups_test.go
@@ -227,3 +227,110 @@ func TestWriteupFlowAndVisibility(t *testing.T) {
 		t.Fatalf("expected 404 for deleted writeup, got %d body=%s", deletedDetailRec.Code, deletedDetailRec.Body.String())
 	}
 }
+
+func TestChallengeCreatorWriteupAccess(t *testing.T) {
+	env := setupTest(t, testCfg)
+	_ = createUser(t, env, "author-admin@example.com", "author_admin", "adminpass", "admin")
+	writer := createUser(t, env, "author-writer@example.com", "author_writer", "pass", "user")
+
+	adminAccess, _, _ := loginUser(t, env.router, "author-admin@example.com", "adminpass")
+	writerAccess, _, _ := loginUser(t, env.router, writer.Email, "pass")
+
+	createChallengeRec := doRequest(t, env.router, http.MethodPost, "/api/admin/challenges", map[string]any{
+		"title":       "Author Writeup Target",
+		"description": "desc",
+		"category":    "Web",
+		"points":      400,
+		"flag":        "flag{author-writeup-target}",
+		"is_active":   true,
+	}, authHeader(adminAccess))
+	if createChallengeRec.Code != http.StatusCreated {
+		t.Fatalf("create challenge status %d: %s", createChallengeRec.Code, createChallengeRec.Body.String())
+	}
+
+	var createdChallenge struct {
+		ID int64 `json:"id"`
+	}
+	decodeJSON(t, createChallengeRec, &createdChallenge)
+
+	createAuthorWriteupRec := doRequest(t, env.router, http.MethodPost, "/api/challenges/"+itoa(createdChallenge.ID)+"/writeups", map[string]any{
+		"content": "Author-side writeup",
+	}, authHeader(adminAccess))
+	if createAuthorWriteupRec.Code != http.StatusCreated {
+		t.Fatalf("expected challenge creator to write before solve, got %d body=%s", createAuthorWriteupRec.Code, createAuthorWriteupRec.Body.String())
+	}
+
+	submitRec := doRequest(t, env.router, http.MethodPost, "/api/challenges/"+itoa(createdChallenge.ID)+"/submit", map[string]any{
+		"flag": "flag{author-writeup-target}",
+	}, authHeader(writerAccess))
+	if submitRec.Code != http.StatusOK {
+		t.Fatalf("writer submit status %d: %s", submitRec.Code, submitRec.Body.String())
+	}
+
+	createWriterWriteupRec := doRequest(t, env.router, http.MethodPost, "/api/challenges/"+itoa(createdChallenge.ID)+"/writeups", map[string]any{
+		"content": "Solver-side writeup",
+	}, authHeader(writerAccess))
+	if createWriterWriteupRec.Code != http.StatusCreated {
+		t.Fatalf("writer create writeup status %d: %s", createWriterWriteupRec.Code, createWriterWriteupRec.Body.String())
+	}
+
+	var writerWriteup struct {
+		ID int64 `json:"id"`
+	}
+	decodeJSON(t, createWriterWriteupRec, &writerWriteup)
+
+	listByAuthorRec := doRequest(t, env.router, http.MethodGet, "/api/challenges/"+itoa(createdChallenge.ID)+"/writeups?page=1&page_size=10", nil, authHeader(adminAccess))
+	if listByAuthorRec.Code != http.StatusOK {
+		t.Fatalf("author list status %d: %s", listByAuthorRec.Code, listByAuthorRec.Body.String())
+	}
+
+	var authorList struct {
+		Writeups []struct {
+			Content *string `json:"content"`
+		} `json:"writeups"`
+		CanViewContent bool `json:"can_view_content"`
+	}
+	decodeJSON(t, listByAuthorRec, &authorList)
+	if !authorList.CanViewContent || len(authorList.Writeups) != 2 {
+		t.Fatalf("unexpected author list response: %+v", authorList)
+	}
+
+	for _, writeup := range authorList.Writeups {
+		if writeup.Content == nil || *writeup.Content == "" {
+			t.Fatalf("expected author to see all writeup content: %+v", authorList)
+		}
+	}
+
+	detailByAuthorRec := doRequest(t, env.router, http.MethodGet, "/api/writeups/"+itoa(writerWriteup.ID), nil, authHeader(adminAccess))
+	if detailByAuthorRec.Code != http.StatusOK {
+		t.Fatalf("author detail status %d: %s", detailByAuthorRec.Code, detailByAuthorRec.Body.String())
+	}
+
+	var authorDetail struct {
+		CanViewContent bool `json:"can_view_content"`
+		Writeup        struct {
+			Content *string `json:"content"`
+		} `json:"writeup"`
+	}
+
+	decodeJSON(t, detailByAuthorRec, &authorDetail)
+	if !authorDetail.CanViewContent || authorDetail.Writeup.Content == nil || *authorDetail.Writeup.Content != "Solver-side writeup" {
+		t.Fatalf("unexpected author detail response: %+v", authorDetail)
+	}
+
+	userWriteupsByAuthorRec := doRequest(t, env.router, http.MethodGet, "/api/users/"+itoa(writer.ID)+"/writeups?page=1&page_size=10", nil, authHeader(adminAccess))
+	if userWriteupsByAuthorRec.Code != http.StatusOK {
+		t.Fatalf("author user writeups status %d: %s", userWriteupsByAuthorRec.Code, userWriteupsByAuthorRec.Body.String())
+	}
+
+	var userWriteupsByAuthor struct {
+		Writeups []struct {
+			Content *string `json:"content"`
+		} `json:"writeups"`
+	}
+
+	decodeJSON(t, userWriteupsByAuthorRec, &userWriteupsByAuthor)
+	if len(userWriteupsByAuthor.Writeups) != 1 || userWriteupsByAuthor.Writeups[0].Content == nil || *userWriteupsByAuthor.Writeups[0].Content != "Solver-side writeup" {
+		t.Fatalf("unexpected author user writeups response: %+v", userWriteupsByAuthor)
+	}
+}

--- a/internal/models/writeup.go
+++ b/internal/models/writeup.go
@@ -18,19 +18,20 @@ type Writeup struct {
 }
 
 type WriteupDetail struct {
-	ID                int64     `bun:"id"`
-	UserID            int64     `bun:"user_id"`
-	ChallengeID       int64     `bun:"challenge_id"`
-	Content           string    `bun:"content"`
-	CreatedAt         time.Time `bun:"created_at"`
-	UpdatedAt         time.Time `bun:"updated_at"`
-	Username          string    `bun:"username"`
-	AffiliationID     *int64    `bun:"affiliation_id"`
-	Affiliation       *string   `bun:"affiliation"`
-	Bio               *string   `bun:"bio"`
-	ProfileImage      *string   `bun:"profile_image"`
-	ChallengeTitle    string    `bun:"challenge_title"`
-	ChallengeCategory string    `bun:"challenge_category"`
-	ChallengePoints   int       `bun:"challenge_points"`
-	ChallengeLevel    int       `bun:"challenge_level"`
+	ID                       int64     `bun:"id"`
+	UserID                   int64     `bun:"user_id"`
+	ChallengeID              int64     `bun:"challenge_id"`
+	Content                  string    `bun:"content"`
+	CreatedAt                time.Time `bun:"created_at"`
+	UpdatedAt                time.Time `bun:"updated_at"`
+	Username                 string    `bun:"username"`
+	AffiliationID            *int64    `bun:"affiliation_id"`
+	Affiliation              *string   `bun:"affiliation"`
+	Bio                      *string   `bun:"bio"`
+	ProfileImage             *string   `bun:"profile_image"`
+	ChallengeTitle           string    `bun:"challenge_title"`
+	ChallengeCategory        string    `bun:"challenge_category"`
+	ChallengePoints          int       `bun:"challenge_points"`
+	ChallengeCreatedByUserID *int64    `bun:"challenge_created_by_user_id"`
+	ChallengeLevel           int       `bun:"challenge_level"`
 }

--- a/internal/repo/writeup_repo.go
+++ b/internal/repo/writeup_repo.go
@@ -90,6 +90,7 @@ func (r *WriteupRepo) baseDetailQuery(includeContent bool) *bun.SelectQuery {
 		ColumnExpr("c.title AS challenge_title").
 		ColumnExpr("c.category AS challenge_category").
 		ColumnExpr("c.points AS challenge_points").
+		ColumnExpr("c.created_by_user_id AS challenge_created_by_user_id").
 		Join("JOIN users AS u ON u.id = w.user_id").
 		Join("JOIN challenges AS c ON c.id = w.challenge_id").
 		Join("LEFT JOIN affiliations AS aff ON aff.id = u.affiliation_id")

--- a/internal/service/wargame_service.go
+++ b/internal/service/wargame_service.go
@@ -1336,7 +1336,7 @@ func (s *WargameService) GetWriteupByID(ctx context.Context, writeupID, viewerUs
 		return nil, false, fmt.Errorf("wargame.GetWriteupByID detail: %w", err)
 	}
 
-	canViewContent, err := s.canAccessWriteupContentByChallengeID(ctx, viewerUserID, row.ChallengeID)
+	canViewContent, err := s.canAccessWriteupContentForChallenge(ctx, viewerUserID, row.ChallengeID, row.ChallengeCreatedByUserID)
 	if err != nil {
 		return nil, false, fmt.Errorf("wargame.GetWriteupByID access check: %w", err)
 	}
@@ -1440,12 +1440,31 @@ func (s *WargameService) UserWriteupsPage(ctx context.Context, targetUserID, vie
 		return nil, models.Pagination{}, fmt.Errorf("wargame.UserWriteupsPage level: %w", err)
 	}
 
-	for i := range rows {
-		canViewContent, err := s.canAccessWriteupContentByChallengeID(ctx, viewerUserID, rows[i].ChallengeID)
+	canViewByChallengeID := make(map[int64]struct{}, len(rows))
+	if viewerUserID > 0 && len(rows) > 0 {
+		solvedIDs, err := s.submissionRepo.SolvedChallengeIDs(ctx, viewerUserID)
 		if err != nil {
-			return nil, models.Pagination{}, fmt.Errorf("wargame.UserWriteupsPage access check: %w", err)
+			return nil, models.Pagination{}, fmt.Errorf("wargame.UserWriteupsPage solved ids: %w", err)
 		}
-		if !canViewContent {
+
+		for _, row := range rows {
+			if _, ok := canViewByChallengeID[row.ChallengeID]; ok {
+				continue
+			}
+
+			if _, ok := solvedIDs[row.ChallengeID]; ok {
+				canViewByChallengeID[row.ChallengeID] = struct{}{}
+				continue
+			}
+
+			if row.ChallengeCreatedByUserID != nil && *row.ChallengeCreatedByUserID == viewerUserID {
+				canViewByChallengeID[row.ChallengeID] = struct{}{}
+			}
+		}
+	}
+
+	for i := range rows {
+		if _, ok := canViewByChallengeID[rows[i].ChallengeID]; !ok {
 			rows[i].Content = ""
 		}
 	}
@@ -1453,32 +1472,24 @@ func (s *WargameService) UserWriteupsPage(ctx context.Context, targetUserID, vie
 	return rows, BuildPagination(params.Page, params.PageSize, totalCount), nil
 }
 
-func (s *WargameService) canAccessWriteupContentByChallengeID(ctx context.Context, userID, challengeID int64) (bool, error) {
-	if userID <= 0 {
-		return false, nil
-	}
-
-	challenge, err := s.challengeRepo.GetByID(ctx, challengeID)
-	if err != nil {
-		if errors.Is(err, repo.ErrNotFound) {
-			return false, ErrChallengeNotFound
-		}
-		return false, err
-	}
-
-	return s.canAccessWriteupContent(ctx, userID, challenge)
-}
-
 func (s *WargameService) canAccessWriteupContent(ctx context.Context, userID int64, challenge *models.Challenge) (bool, error) {
 	if userID <= 0 || challenge == nil {
 		return false, nil
 	}
 
-	if challenge.CreatedByUserID != nil && *challenge.CreatedByUserID == userID {
+	return s.canAccessWriteupContentForChallenge(ctx, userID, challenge.ID, challenge.CreatedByUserID)
+}
+
+func (s *WargameService) canAccessWriteupContentForChallenge(ctx context.Context, userID, challengeID int64, createdByUserID *int64) (bool, error) {
+	if userID <= 0 {
+		return false, nil
+	}
+
+	if createdByUserID != nil && *createdByUserID == userID {
 		return true, nil
 	}
 
-	return s.submissionRepo.HasCorrect(ctx, userID, challenge.ID)
+	return s.submissionRepo.HasCorrect(ctx, userID, challengeID)
 }
 
 func (s *WargameService) applyWriteupChallengeLevels(ctx context.Context, rows []*models.WriteupDetail) error {

--- a/internal/service/wargame_service.go
+++ b/internal/service/wargame_service.go
@@ -995,7 +995,8 @@ func (s *WargameService) CreateWriteup(ctx context.Context, userID, challengeID 
 		return nil, err
 	}
 
-	if _, err := s.challengeRepo.GetByID(ctx, challengeID); err != nil {
+	challenge, err := s.challengeRepo.GetByID(ctx, challengeID)
+	if err != nil {
 		if errors.Is(err, repo.ErrNotFound) {
 			return nil, ErrChallengeNotFound
 		}
@@ -1003,12 +1004,12 @@ func (s *WargameService) CreateWriteup(ctx context.Context, userID, challengeID 
 		return nil, fmt.Errorf("wargame.CreateWriteup challenge lookup: %w", err)
 	}
 
-	solved, err := s.submissionRepo.HasCorrect(ctx, userID, challengeID)
+	canCreate, err := s.canAccessWriteupContent(ctx, userID, challenge)
 	if err != nil {
-		return nil, fmt.Errorf("wargame.CreateWriteup solved check: %w", err)
+		return nil, fmt.Errorf("wargame.CreateWriteup access check: %w", err)
 	}
 
-	if !solved {
+	if !canCreate {
 		return nil, ErrChallengeNotSolvedByUser
 	}
 
@@ -1284,7 +1285,8 @@ func (s *WargameService) ChallengeWriteupsPage(ctx context.Context, challengeID,
 		return nil, models.Pagination{}, false, ErrInvalidInput
 	}
 
-	if _, err := s.challengeRepo.GetByID(ctx, challengeID); err != nil {
+	challenge, err := s.challengeRepo.GetByID(ctx, challengeID)
+	if err != nil {
 		if errors.Is(err, repo.ErrNotFound) {
 			return nil, models.Pagination{}, false, ErrChallengeNotFound
 		}
@@ -1292,12 +1294,9 @@ func (s *WargameService) ChallengeWriteupsPage(ctx context.Context, challengeID,
 		return nil, models.Pagination{}, false, fmt.Errorf("wargame.ChallengeWriteupsPage challenge lookup: %w", err)
 	}
 
-	canViewContent := false
-	if viewerUserID > 0 {
-		canViewContent, err = s.submissionRepo.HasCorrect(ctx, viewerUserID, challengeID)
-		if err != nil {
-			return nil, models.Pagination{}, false, fmt.Errorf("wargame.ChallengeWriteupsPage viewer solved check: %w", err)
-		}
+	canViewContent, err := s.canAccessWriteupContent(ctx, viewerUserID, challenge)
+	if err != nil {
+		return nil, models.Pagination{}, false, fmt.Errorf("wargame.ChallengeWriteupsPage access check: %w", err)
 	}
 
 	var rows []models.WriteupDetail
@@ -1337,12 +1336,9 @@ func (s *WargameService) GetWriteupByID(ctx context.Context, writeupID, viewerUs
 		return nil, false, fmt.Errorf("wargame.GetWriteupByID detail: %w", err)
 	}
 
-	canViewContent := false
-	if viewerUserID > 0 {
-		canViewContent, err = s.submissionRepo.HasCorrect(ctx, viewerUserID, row.ChallengeID)
-		if err != nil {
-			return nil, false, fmt.Errorf("wargame.GetWriteupByID viewer solved check: %w", err)
-		}
+	canViewContent, err := s.canAccessWriteupContentByChallengeID(ctx, viewerUserID, row.ChallengeID)
+	if err != nil {
+		return nil, false, fmt.Errorf("wargame.GetWriteupByID access check: %w", err)
 	}
 
 	if canViewContent {
@@ -1444,24 +1440,45 @@ func (s *WargameService) UserWriteupsPage(ctx context.Context, targetUserID, vie
 		return nil, models.Pagination{}, fmt.Errorf("wargame.UserWriteupsPage level: %w", err)
 	}
 
-	if viewerUserID > 0 {
-		solvedIDs, err := s.SolvedChallengeIDs(ctx, viewerUserID)
+	for i := range rows {
+		canViewContent, err := s.canAccessWriteupContentByChallengeID(ctx, viewerUserID, rows[i].ChallengeID)
 		if err != nil {
-			return nil, models.Pagination{}, fmt.Errorf("wargame.UserWriteupsPage solved ids: %w", err)
+			return nil, models.Pagination{}, fmt.Errorf("wargame.UserWriteupsPage access check: %w", err)
 		}
-
-		for i := range rows {
-			if _, ok := solvedIDs[rows[i].ChallengeID]; !ok {
-				rows[i].Content = ""
-			}
-		}
-	} else {
-		for i := range rows {
+		if !canViewContent {
 			rows[i].Content = ""
 		}
 	}
 
 	return rows, BuildPagination(params.Page, params.PageSize, totalCount), nil
+}
+
+func (s *WargameService) canAccessWriteupContentByChallengeID(ctx context.Context, userID, challengeID int64) (bool, error) {
+	if userID <= 0 {
+		return false, nil
+	}
+
+	challenge, err := s.challengeRepo.GetByID(ctx, challengeID)
+	if err != nil {
+		if errors.Is(err, repo.ErrNotFound) {
+			return false, ErrChallengeNotFound
+		}
+		return false, err
+	}
+
+	return s.canAccessWriteupContent(ctx, userID, challenge)
+}
+
+func (s *WargameService) canAccessWriteupContent(ctx context.Context, userID int64, challenge *models.Challenge) (bool, error) {
+	if userID <= 0 || challenge == nil {
+		return false, nil
+	}
+
+	if challenge.CreatedByUserID != nil && *challenge.CreatedByUserID == userID {
+		return true, nil
+	}
+
+	return s.submissionRepo.HasCorrect(ctx, userID, challenge.ID)
 }
 
 func (s *WargameService) applyWriteupChallengeLevels(ctx context.Context, rows []*models.WriteupDetail) error {

--- a/internal/service/wargame_service_test.go
+++ b/internal/service/wargame_service_test.go
@@ -1031,6 +1031,74 @@ func TestWargameServiceWriteupLifecycle(t *testing.T) {
 	}
 }
 
+func TestWargameServiceChallengeCreatorWriteupAccess(t *testing.T) {
+	env := setupServiceTest(t)
+	creator := createUser(t, env, "writeup-creator@example.com", "writeup_creator", "pass", models.UserRole)
+	writer := createUser(t, env, "writeup-solver@example.com", "writeup_solver", "pass", models.UserRole)
+	challenge := createChallenge(t, env, "Creator Writeup Challenge", 300, "flag{creator}", true)
+
+	if err := env.wargameSvc.UpdateChallengeCreator(context.Background(), challenge.ID, creator.ID); err != nil {
+		t.Fatalf("UpdateChallengeCreator: %v", err)
+	}
+
+	creatorWriteup, err := env.wargameSvc.CreateWriteup(context.Background(), creator.ID, challenge.ID, "Author notes")
+	if err != nil {
+		t.Fatalf("creator CreateWriteup without solve: %v", err)
+	}
+
+	if creatorWriteup.Content != "Author notes" {
+		t.Fatalf("unexpected creator writeup: %+v", creatorWriteup)
+	}
+
+	createSubmission(t, env, writer.ID, challenge.ID, true, time.Now().UTC())
+	writerWriteup, err := env.wargameSvc.CreateWriteup(context.Background(), writer.ID, challenge.ID, "Solver notes")
+	if err != nil {
+		t.Fatalf("writer CreateWriteup: %v", err)
+	}
+
+	rows, pagination, canView, err := env.wargameSvc.ChallengeWriteupsPage(context.Background(), challenge.ID, creator.ID, 1, 10)
+	if err != nil {
+		t.Fatalf("ChallengeWriteupsPage creator: %v", err)
+	}
+
+	if !canView || len(rows) != 2 || pagination.TotalCount != 2 {
+		t.Fatalf("unexpected creator challenge writeups view: canView=%v rows=%+v pagination=%+v", canView, rows, pagination)
+	}
+
+	for _, row := range rows {
+		if row.Content == "" {
+			t.Fatalf("expected creator to see all writeup content, got rows=%+v", rows)
+		}
+	}
+
+	row, canView, err := env.wargameSvc.GetWriteupByID(context.Background(), writerWriteup.ID, creator.ID)
+	if err != nil {
+		t.Fatalf("GetWriteupByID creator: %v", err)
+	}
+
+	if !canView || row.Content != "Solver notes" {
+		t.Fatalf("expected creator to see solver writeup, canView=%v row=%+v", canView, row)
+	}
+
+	userRows, userPagination, err := env.wargameSvc.UserWriteupsPage(context.Background(), writer.ID, creator.ID, 1, 10)
+	if err != nil {
+		t.Fatalf("UserWriteupsPage creator: %v", err)
+	}
+
+	if len(userRows) != 1 || userRows[0].Content != "Solver notes" || userPagination.TotalCount != 1 {
+		t.Fatalf("unexpected creator user writeups view: rows=%+v pagination=%+v", userRows, userPagination)
+	}
+
+	anonymousRow, anonymousCanView, err := env.wargameSvc.GetWriteupByID(context.Background(), writerWriteup.ID, 0)
+	if err != nil {
+		t.Fatalf("GetWriteupByID anonymous: %v", err)
+	}
+
+	if anonymousCanView || anonymousRow.Content != "" {
+		t.Fatalf("expected anonymous viewer content to be hidden, canView=%v row=%+v", anonymousCanView, anonymousRow)
+	}
+}
+
 func TestWargameServiceWriteupValidationAndLookupErrors(t *testing.T) {
 	env := setupServiceTest(t)
 	user := createUser(t, env, "writeup-validate@example.com", "writeup_validate", "pass", models.UserRole)
@@ -1117,6 +1185,39 @@ func TestWargameServiceWriteupValidationAndLookupErrors(t *testing.T) {
 
 	if _, _, err := env.wargameSvc.UserWriteupsPage(context.Background(), 0, user.ID, 1, 10); !errors.Is(err, ErrInvalidInput) {
 		t.Fatalf("expected invalid input for target user_id=0, got %v", err)
+	}
+}
+
+func TestWargameServiceWriteupAccessRepoFailures(t *testing.T) {
+	env := setupServiceTest(t)
+	user := createUser(t, env, "writeup-access-fail@example.com", "writeup_access_fail", "pass", models.UserRole)
+	writer := createUser(t, env, "writeup-access-writer@example.com", "writeup_access_writer", "pass", models.UserRole)
+	challenge := createChallenge(t, env, "Writeup Access Failure", 200, "flag{waf}", true)
+	createSubmission(t, env, writer.ID, challenge.ID, true, time.Now().UTC())
+	created, err := env.wargameSvc.CreateWriteup(context.Background(), writer.ID, challenge.ID, "body")
+	if err != nil {
+		t.Fatalf("seed writeup: %v", err)
+	}
+
+	closedDB := newClosedServiceDB(t)
+	brokenSubmissions := repo.NewSubmissionRepo(closedDB)
+	origSvc := env.wargameSvc
+	env.wargameSvc = NewWargameService(env.cfg, env.challengeRepo, brokenSubmissions, repo.NewChallengeVoteRepo(env.db), repo.NewWriteupRepo(env.db), repo.NewChallengeCommentRepo(env.db), repo.NewCommunityRepo(env.db), env.redis, origSvc.fileStore)
+
+	if _, err := env.wargameSvc.CreateWriteup(context.Background(), user.ID, challenge.ID, "blocked"); err == nil {
+		t.Fatalf("expected create writeup access check failure")
+	}
+
+	if _, _, _, err := env.wargameSvc.ChallengeWriteupsPage(context.Background(), challenge.ID, user.ID, 1, 10); err == nil {
+		t.Fatalf("expected challenge writeups access check failure")
+	}
+
+	if _, _, err := env.wargameSvc.GetWriteupByID(context.Background(), created.ID, user.ID); err == nil {
+		t.Fatalf("expected get writeup access check failure")
+	}
+
+	if _, _, err := env.wargameSvc.UserWriteupsPage(context.Background(), writer.ID, user.ID, 1, 10); err == nil {
+		t.Fatalf("expected user writeups access check failure")
 	}
 }
 


### PR DESCRIPTION
Previously, even challenge authors had to solve their own challenge in order to create a writeup or view writeups written by other users.

This PR changes the behavior so that challenge authors can create and view writeups regardless of whether they have solved the challenge.
