### PR TITLE
Allow Challenge Authors to Access and Interact with Locked Challenges

### DIFF
--- a/docs/docs/challenges.md
+++ b/docs/docs/challenges.md
@@ -71,6 +71,7 @@ Notes:
 
 - `points` is fixed and equals the challenge author's configured score.
 - If a challenge is locked by progression, it is returned in a reduced form with `is_locked: true`.
+- The challenge creator bypasses progression locks for their own challenge.
 
 Errors:
 
@@ -416,6 +417,10 @@ Errors:
 - 404 `challenge not found` or `challenge file not found`
 - 503 `storage unavailable`
 
+Notes:
+
+- The challenge creator can still submit to and download files from their own progression-locked challenge.
+
 ---
 
 ## List Challenge Comments
@@ -690,6 +695,7 @@ Notes:
 
 - Series challenges are returned in admin-defined order.
 - If a challenge is progression-locked, it is returned in reduced form with `is_locked: true`.
+- The challenge creator bypasses progression locks for their own challenge entries.
 
 Errors:
 

--- a/docs/docs/stacks.md
+++ b/docs/docs/stacks.md
@@ -100,6 +100,10 @@ Errors:
 - 429 `too many submissions`
 - 503 `stack feature disabled` or `stack provisioner unavailable`
 
+Notes:
+
+- The challenge creator can create a stack for their own challenge even when it has a prerequisite challenge configured.
+
 ---
 
 ## Get Stack For Challenge

--- a/docs/docs/vms.md
+++ b/docs/docs/vms.md
@@ -125,6 +125,7 @@ Errors:
 Create behavior:
 
 - Challenge must have `vm_enabled=true` and non-empty `vm_spec` (YAML).
+- The challenge creator can create a VM for their own challenge even when it has a prerequisite challenge configured.
 - Solved users can still create or recreate VMs for the same challenge.
 - Wargame parses the YAML, rewrites `id` to generated `vm_id`, and sends the rewritten spec to orchestrator.
 - If an existing VM row already exists for `(user_id, challenge_id)`, create returns the existing VM instead of creating a second one.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -176,10 +176,10 @@ const App = () => {
     if (false) {
         return (
             <div className='flex min-h-screen items-center justify-center bg-slate-950 px-4'>
-                <div className='w-full max-w-md rounded-2xl border border-slate-700 bg-slate-900 px-8 py-10 text-center shadow-2xl'>
-                    <h1 className='text-2xl font-bold text-white'>서버 운영 시간이 아닙니다.</h1>
+                <div className='w-full max-w-md border border-slate-700 bg-slate-900 px-8 py-10 text-center shadow-2xl'>
+                    <h1 className='text-2xl font-bold text-white'>서버 점검 중</h1>
 
-                    <p className='mt-4 text-sm text-slate-400'>주인장 서버 컴퓨터도 밤엔 자야합니다. 아침 시간대에 다시 방문해주세요.</p>
+                    <p className='mt-4 text-sm text-slate-400'>나중에 다시 방문해주세요.</p>
                 </div>
             </div>
         )

--- a/frontend/src/routes/ChallengeDetail.tsx
+++ b/frontend/src/routes/ChallengeDetail.tsx
@@ -275,7 +275,7 @@ const ChallengeDetail = ({ routeParams = {} }: RouteProps) => {
     useEffect(() => {
         if (!challengeId) return
         void loadChallenge()
-    }, [challengeId])
+    }, [challengeId, auth.user?.id])
 
     const loadStack = async () => {
         if (!challengeId || !stackEnabled) return

--- a/frontend/src/routes/WriteupDetail.tsx
+++ b/frontend/src/routes/WriteupDetail.tsx
@@ -57,7 +57,7 @@ const WriteupDetail = ({ routeParams = {} }: RouteProps) => {
 
     useEffect(() => {
         void loadWriteup()
-    }, [writeupID])
+    }, [writeupID, auth.user?.id])
 
     const deleteWriteup = async () => {
         if (!writeup || deleting) return

--- a/internal/http/handlers/handler.go
+++ b/internal/http/handlers/handler.go
@@ -230,6 +230,9 @@ func isChallengeLocked(challenge models.Challenge, solved map[int64]struct{}, us
 		return false
 	}
 
+	if challenge.CreatedByUserID != nil && userID > 0 && *challenge.CreatedByUserID == userID {
+		return false
+	}
 	if userID <= 0 {
 		return true
 	}

--- a/internal/http/handlers/handler_test.go
+++ b/internal/http/handlers/handler_test.go
@@ -66,6 +66,28 @@ func TestHandlerCreateAndUpdateChallenge(t *testing.T) {
 	})
 }
 
+func TestIsChallengeLocked(t *testing.T) {
+	prevID := int64(11)
+	creatorID := int64(21)
+	challenge := models.Challenge{PreviousChallengeID: &prevID, CreatedByUserID: &creatorID}
+
+	if !isChallengeLocked(challenge, map[int64]struct{}{}, 0) {
+		t.Fatalf("anonymous user should see locked challenge")
+	}
+	if isChallengeLocked(challenge, map[int64]struct{}{}, creatorID) {
+		t.Fatalf("creator should bypass challenge lock")
+	}
+	if isChallengeLocked(challenge, map[int64]struct{}{prevID: {}}, 30) {
+		t.Fatalf("solver of prerequisite should bypass challenge lock")
+	}
+	if !isChallengeLocked(challenge, map[int64]struct{}{}, 30) {
+		t.Fatalf("unsolved non-creator should remain locked")
+	}
+	if isChallengeLocked(models.Challenge{}, map[int64]struct{}{}, 30) {
+		t.Fatalf("challenge without prerequisite must not be locked")
+	}
+}
+
 func TestHandlerChallengeLevelVote(t *testing.T) {
 	env := setupHandlerTest(t)
 	user := createHandlerUser(t, env, "solver@example.com", "solver", "pass", models.UserRole)
@@ -1536,6 +1558,33 @@ func TestHandlerGetChallengeAndSolvers(t *testing.T) {
 
 		if resp.FirstBlood == nil || resp.FirstBlood.UserID != user.ID || !resp.FirstBlood.IsFirstBlood {
 			t.Fatalf("expected first blood in detail response, got %+v", resp.FirstBlood)
+		}
+	})
+
+	t.Run("challenge creator bypasses locked response", func(t *testing.T) {
+		locked.CreatedByUserID = &user.ID
+		if err := env.challengeRepo.Update(context.Background(), locked); err != nil {
+			t.Fatalf("set creator: %v", err)
+		}
+
+		ctx, rec := newJSONContext(t, http.MethodGet, "/api/challenges/"+toStringID(locked.ID), nil)
+		ctx.Request.AddCookie(&http.Cookie{Name: "access_token", Value: token})
+		ctx.Params = append(ctx.Params, ginParam("id", toStringID(locked.ID)))
+		env.handler.GetChallenge(ctx)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status %d: %s", rec.Code, rec.Body.String())
+		}
+
+		var resp challengeResponse
+		if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+
+		if resp.IsLocked {
+			t.Fatalf("expected creator to receive unlocked response: %+v", resp)
+		}
+		if resp.Description == "" {
+			t.Fatalf("expected creator to receive challenge description")
 		}
 	})
 

--- a/internal/http/integration/challenges_test.go
+++ b/internal/http/integration/challenges_test.go
@@ -963,6 +963,77 @@ func TestChallengeSeriesCRUDAndOrder(t *testing.T) {
 		t.Fatalf("expected locked challenge to be summarized without description: %+v", detail.Challenges[1])
 	}
 
+	rec = doRequest(t, env.router, http.MethodGet, "/api/challenges/"+itoa(lockedID), nil, authHeader(adminAccess))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("author detail status %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var authorDetail struct {
+		IsLocked    bool   `json:"is_locked"`
+		Description string `json:"description"`
+	}
+	decodeJSON(t, rec, &authorDetail)
+	if authorDetail.IsLocked || authorDetail.Description == "" {
+		t.Fatalf("expected author unlocked detail response: %+v", authorDetail)
+	}
+
+	rec = doRequest(t, env.router, http.MethodGet, "/api/challenges?page=1&page_size=20", nil, authHeader(adminAccess))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("author list status %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var authorList struct {
+		Challenges []map[string]any `json:"challenges"`
+	}
+	decodeJSON(t, rec, &authorList)
+
+	foundUnlocked := false
+	for _, item := range authorList.Challenges {
+		id, _ := item["id"].(float64)
+		if int64(id) != lockedID {
+			continue
+		}
+
+		if _, ok := item["description"]; !ok {
+			t.Fatalf("expected author list entry to include description: %+v", item)
+		}
+
+		if isLocked, _ := item["is_locked"].(bool); isLocked {
+			t.Fatalf("expected author list entry unlocked: %+v", item)
+		}
+
+		foundUnlocked = true
+	}
+
+	if !foundUnlocked {
+		t.Fatalf("expected locked challenge in author list: %+v", authorList.Challenges)
+	}
+
+	rec = doRequest(t, env.router, http.MethodGet, "/api/challenge-series/"+itoa(created.ID), nil, authHeader(adminAccess))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("author series detail status %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var authorSeriesDetail struct {
+		Challenges []map[string]any `json:"challenges"`
+	}
+	decodeJSON(t, rec, &authorSeriesDetail)
+
+	for _, item := range authorSeriesDetail.Challenges {
+		id, _ := item["id"].(float64)
+		if int64(id) != lockedID {
+			continue
+		}
+
+		if _, ok := item["description"]; !ok {
+			t.Fatalf("expected author series entry to include description: %+v", item)
+		}
+
+		if isLocked, _ := item["is_locked"].(bool); isLocked {
+			t.Fatalf("expected author series entry unlocked: %+v", item)
+		}
+	}
+
 	rec = doRequest(t, env.router, http.MethodPut, "/api/admin/challenge-series/"+itoa(created.ID), map[string]any{
 		"title": "Starter Challenge Series Updated",
 	}, authHeader(adminAccess))

--- a/internal/service/stack_service.go
+++ b/internal/service/stack_service.go
@@ -322,6 +322,10 @@ func (s *StackService) ensureUnlocked(ctx context.Context, userID int64, challen
 		return nil
 	}
 
+	if canBypassChallengeProgression(userID, challenge.CreatedByUserID) {
+		return nil
+	}
+
 	if userID <= 0 || s.submissionRepo == nil {
 		return ErrChallengeLocked
 	}

--- a/internal/service/stack_service_test.go
+++ b/internal/service/stack_service_test.go
@@ -198,6 +198,7 @@ func TestStackServiceRateLimitAndUserLimit(t *testing.T) {
 func TestStackServiceChallengeStateAndSolvedPaths(t *testing.T) {
 	env := setupServiceTest(t)
 	user := createUser(t, env, "state@example.com", "state", "pass", models.UserRole)
+	creator := createUser(t, env, "state-creator@example.com", "state-creator", "pass", models.UserRole)
 
 	notEnabled := createChallenge(t, env, "NoStack", 100, "FLAG{NS}", true)
 	stackSvc, _ := newStackService(env, stack.NewProvisionerMock().Client(), config.StackConfig{Enabled: true, MaxPer: 2, CreateWindow: time.Minute, CreateMax: 5})
@@ -217,11 +218,15 @@ func TestStackServiceChallengeStateAndSolvedPaths(t *testing.T) {
 	prev := createChallenge(t, env, "Prev", 50, "FLAG{PREV}", true)
 	locked := createStackChallenge(t, env, "Locked")
 	locked.PreviousChallengeID = &prev.ID
+	locked.CreatedByUserID = &creator.ID
 	if err := env.challengeRepo.Update(context.Background(), locked); err != nil {
 		t.Fatalf("update locked challenge: %v", err)
 	}
 	if _, err := stackSvc.GetOrCreateStack(context.Background(), user.ID, locked.ID); !errors.Is(err, ErrChallengeLocked) {
 		t.Fatalf("expected ErrChallengeLocked, got %v", err)
+	}
+	if _, err := stackSvc.GetOrCreateStack(context.Background(), creator.ID, locked.ID); err != nil {
+		t.Fatalf("expected creator bypass stack create, got %v", err)
 	}
 	createSubmission(t, env, user.ID, prev.ID, true, time.Now().UTC())
 	if _, err := stackSvc.GetOrCreateStack(context.Background(), user.ID, locked.ID); err != nil {

--- a/internal/service/vm_service.go
+++ b/internal/service/vm_service.go
@@ -228,6 +228,9 @@ func (s *VMService) ensureUnlocked(ctx context.Context, userID int64, challenge 
 		return nil
 	}
 
+	if canBypassChallengeProgression(userID, challenge.CreatedByUserID) {
+		return nil
+	}
 	if userID <= 0 || s.submissionRepo == nil {
 		return ErrChallengeLocked
 	}

--- a/internal/service/vm_service_test.go
+++ b/internal/service/vm_service_test.go
@@ -127,6 +127,35 @@ func TestVMServiceGetOrCreateVMAllowsSolvedChallenge(t *testing.T) {
 	}
 }
 
+func TestVMServiceGetOrCreateVMAllowsCreatorBypassOnLockedChallenge(t *testing.T) {
+	env := setupServiceTest(t)
+	creator := createUser(t, env, "vm-creator@example.com", "vm-creator", "pass", models.UserRole)
+	viewer := createUser(t, env, "vm-viewer@example.com", "vm-viewer", "pass", models.UserRole)
+	prev := createChallenge(t, env, "vm-prev", 100, "FLAG{VMPREV}", true)
+	challenge := createVMChallenge(t, env, "vm-locked")
+	challenge.PreviousChallengeID = &prev.ID
+	challenge.CreatedByUserID = &creator.ID
+	if err := env.challengeRepo.Update(context.Background(), challenge); err != nil {
+		t.Fatalf("update challenge: %v", err)
+	}
+
+	client := &vm.MockClient{
+		CreateSandboxFn: func(ctx context.Context, id string, specYAML string) (*vm.Sandbox, error) {
+			exp := time.Now().UTC().Add(time.Hour)
+			return &vm.Sandbox{ID: id, Status: vm.SandboxStatus{Phase: "Pending", ExpireAt: &exp}}, nil
+		},
+	}
+	svc, _ := newVMServiceForTest(env, client, config.VMConfig{Enabled: true, MaxPer: 2, CreateWindow: time.Minute, CreateMax: 5})
+
+	if _, err := svc.GetOrCreateVM(context.Background(), creator.ID, challenge.ID); err != nil {
+		t.Fatalf("expected creator bypass vm create, got %v", err)
+	}
+
+	if _, err := svc.GetOrCreateVM(context.Background(), viewer.ID, challenge.ID); !errors.Is(err, ErrChallengeLocked) {
+		t.Fatalf("expected locked vm create for non-creator, got %v", err)
+	}
+}
+
 func TestVMServiceRefreshDoesNotDeleteFailedVM(t *testing.T) {
 	env := setupServiceTest(t)
 	user := createUser(t, env, "vm-failed@example.com", "vm-failed", "pass", models.UserRole)

--- a/internal/service/wargame_service.go
+++ b/internal/service/wargame_service.go
@@ -838,6 +838,9 @@ func (s *WargameService) ensureUnlocked(ctx context.Context, userID int64, chall
 		return nil
 	}
 
+	if canBypassChallengeProgression(userID, challenge.CreatedByUserID) {
+		return nil
+	}
 	if userID <= 0 || s.submissionRepo == nil {
 		return ErrChallengeLocked
 	}
@@ -1881,10 +1884,17 @@ func isChallengeLockedForService(challenge models.Challenge, solved map[int64]st
 		return false
 	}
 
+	if canBypassChallengeProgression(userID, challenge.CreatedByUserID) {
+		return false
+	}
 	if userID <= 0 {
 		return true
 	}
 
 	_, ok := solved[*challenge.PreviousChallengeID]
 	return !ok
+}
+
+func canBypassChallengeProgression(userID int64, createdByUserID *int64) bool {
+	return userID > 0 && createdByUserID != nil && *createdByUserID == userID
 }

--- a/internal/service/wargame_service_test.go
+++ b/internal/service/wargame_service_test.go
@@ -80,6 +80,45 @@ func TestWargameServiceCreateListGetChallenge(t *testing.T) {
 	}
 }
 
+func TestCanBypassChallengeProgression(t *testing.T) {
+	creatorID := int64(7)
+
+	if !canBypassChallengeProgression(creatorID, &creatorID) {
+		t.Fatalf("expected creator to bypass progression")
+	}
+	if canBypassChallengeProgression(0, &creatorID) {
+		t.Fatalf("anonymous user must not bypass progression")
+	}
+	if canBypassChallengeProgression(8, &creatorID) {
+		t.Fatalf("different user must not bypass progression")
+	}
+	if canBypassChallengeProgression(creatorID, nil) {
+		t.Fatalf("nil creator must not bypass progression")
+	}
+}
+
+func TestIsChallengeLockedForService(t *testing.T) {
+	prevID := int64(10)
+	creatorID := int64(20)
+	challenge := models.Challenge{PreviousChallengeID: &prevID, CreatedByUserID: &creatorID}
+
+	if !isChallengeLockedForService(challenge, map[int64]struct{}{}, 0) {
+		t.Fatalf("anonymous user should see locked challenge")
+	}
+	if isChallengeLockedForService(challenge, map[int64]struct{}{}, creatorID) {
+		t.Fatalf("creator should bypass challenge lock")
+	}
+	if isChallengeLockedForService(challenge, map[int64]struct{}{prevID: {}}, 30) {
+		t.Fatalf("solver of prerequisite should bypass challenge lock")
+	}
+	if !isChallengeLockedForService(challenge, map[int64]struct{}{}, 30) {
+		t.Fatalf("unsolved non-creator should remain locked")
+	}
+	if isChallengeLockedForService(models.Challenge{}, map[int64]struct{}{}, 30) {
+		t.Fatalf("challenge without prerequisite must not be locked")
+	}
+}
+
 func TestWargameServiceChallengeCategoryAndLevelCounts(t *testing.T) {
 	env := setupServiceTest(t)
 	createChallengeWithCategory := func(title, category string, active bool, flag string) *models.Challenge {
@@ -593,9 +632,11 @@ func TestWargameServiceValidationAndNotFound(t *testing.T) {
 func TestWargameServiceSubmitFlagLockedAndInactive(t *testing.T) {
 	env := setupServiceTest(t)
 	user := createUser(t, env, "lock@example.com", "lock", "pass", models.UserRole)
+	creator := createUser(t, env, "lock-creator@example.com", "lock-creator", "pass", models.UserRole)
 	prev := createChallenge(t, env, "Prev", 50, "FLAG{PREV}", true)
 	locked := createChallenge(t, env, "Locked", 100, "FLAG{LOCK}", true)
 	locked.PreviousChallengeID = &prev.ID
+	locked.CreatedByUserID = &creator.ID
 	if err := env.challengeRepo.Update(context.Background(), locked); err != nil {
 		t.Fatalf("update locked challenge: %v", err)
 	}
@@ -604,8 +645,13 @@ func TestWargameServiceSubmitFlagLockedAndInactive(t *testing.T) {
 		t.Fatalf("expected ErrChallengeLocked, got %v", err)
 	}
 
+	correct, err := env.wargameSvc.SubmitFlag(context.Background(), creator.ID, locked.ID, "FLAG{LOCK}")
+	if err != nil || !correct {
+		t.Fatalf("expected creator bypass solve, correct=%v err=%v", correct, err)
+	}
+
 	createSubmission(t, env, user.ID, prev.ID, true, time.Now().UTC())
-	correct, err := env.wargameSvc.SubmitFlag(context.Background(), user.ID, locked.ID, "FLAG{LOCK}")
+	correct, err = env.wargameSvc.SubmitFlag(context.Background(), user.ID, locked.ID, "FLAG{LOCK}")
 	if err != nil || !correct {
 		t.Fatalf("expected unlocked solve, correct=%v err=%v", correct, err)
 	}
@@ -642,6 +688,31 @@ func TestWargameServiceFileUploadDownloadDeleteFlow(t *testing.T) {
 	}
 	if cleared.FileKey != nil || cleared.FileName != nil || cleared.FileUploadedAt != nil {
 		t.Fatalf("expected file fields cleared, got %+v", cleared)
+	}
+}
+
+func TestWargameServiceFileDownloadAllowsCreatorBypassOnLockedChallenge(t *testing.T) {
+	env := setupServiceTest(t)
+	creator := createUser(t, env, "zip-creator@example.com", "zip-creator", "pass", models.UserRole)
+	viewer := createUser(t, env, "zip-viewer@example.com", "zip-viewer", "pass", models.UserRole)
+	prev := createChallenge(t, env, "Zip Prev", 100, "FLAG{ZIPPREV}", true)
+	challenge := createChallenge(t, env, "Zip Locked", 100, "FLAG{ZIPLOCK}", true)
+	challenge.PreviousChallengeID = &prev.ID
+	challenge.CreatedByUserID = &creator.ID
+	if err := env.challengeRepo.Update(context.Background(), challenge); err != nil {
+		t.Fatalf("update challenge: %v", err)
+	}
+
+	if _, _, err := env.wargameSvc.RequestChallengeFileUpload(context.Background(), challenge.ID, "bundle.zip"); err != nil {
+		t.Fatalf("RequestChallengeFileUpload: %v", err)
+	}
+
+	if _, err := env.wargameSvc.RequestChallengeFileDownload(context.Background(), creator.ID, challenge.ID); err != nil {
+		t.Fatalf("expected creator download bypass, got %v", err)
+	}
+
+	if _, err := env.wargameSvc.RequestChallengeFileDownload(context.Background(), viewer.ID, challenge.ID); !errors.Is(err, ErrChallengeLocked) {
+		t.Fatalf("expected locked download for non-creator, got %v", err)
 	}
 }
 


### PR DESCRIPTION
Previously, when a challenge was marked as **Locked**, even the original author could not access the challenge or perform actions such as downloading files, creating VMs, or submitting flags.

This PR resolves that issue.

Challenge authors can now perform the following actions on challenges they created:

* View the challenge
* Download challenge files
* Create VMs
* Submit flags

For more details, please refer to the documentation and the changes included in this PR.
